### PR TITLE
Add support to deploy and test on a local cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,40 @@ all: build
 GO=GO111MODULE=on GOFLAGS=-mod=vendor go
 GO_BUILD_BINDIR := bin
 
+ARTIFACTS := "./artifacts/manifests"
+OUTPUT_DIR := "./_output"
+MANIFEST_DIR := "$(OUTPUT_DIR)/manifests"
+CERT_FILE_PATH := "$(OUTPUT_DIR)/certs.yaml"
+MANIFEST_SECRET_YAML := "$(MANIFEST_DIR)/004_secret.yaml"
+MANIFEST_APISERVICE_YAML := "$(MANIFEST_DIR)/007_apiservice.yaml"
+MANIFEST_MUTATING_WEBHOOK_YAML := "$(MANIFEST_DIR)/008_mutating.yaml"
+
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/library-go/alpha-build-machinery/make/, \
 	golang.mk \
 	targets/openshift/images.mk \
 )
 
-# generate image targets
-IMAGE_REGISTRY ?=registry.svc.ci.openshift.org
-$(call build-image,cluster-resource-override-admission,$(IMAGE_REGISTRY)/autoscaling/cluster-resource-override,./images/ci/Dockerfile,.)
+# build image for ci
+CI_IMAGE_REGISTRY ?=registry.svc.ci.openshift.org
+$(call build-image,cluster-resource-override-admission,$(CI_IMAGE_REGISTRY)/autoscaling/cluster-resource-override,./images/ci/Dockerfile,.)
+
+# build image for dev use.
+local-image:
+	docker build -t $(LOCAL_IMAGE_REGISTRY):$(IMAGE_TAG) -f ./images/dev/Dockerfile.dev .
+
+local-push:
+	docker push $(LOCAL_IMAGE_REGISTRY):$(IMAGE_TAG)
+
+# generate manifests for installing on a dev cluster.
+manifests:
+	rm -rf $(MANIFEST_DIR)
+	mkdir -p $(MANIFEST_DIR)
+	cp -r $(ARTIFACTS)/* $(MANIFEST_DIR)/
+
+	# generate certs
+	./hack/generate-cert.sh "$(CERT_FILE_PATH)"
+
+	# load the certs into the manifest yaml.
+	./hack/load-cert-into-manifest.sh "$(CERT_FILE_PATH)" "$(MANIFEST_SECRET_YAML)" "$(MANIFEST_APISERVICE_YAML)" "$(MANIFEST_MUTATING_WEBHOOK_YAML)"
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# Overview
+`ClusterResourceOverride` Mutating Webhook Server.
+
+## Developer Workflow
+### Deploy
+#### Prerequisites:
+* `go`: `1.12` or above
+* `jq`: Install [jq](https://stedolan.github.io/jq)
+* `cfssl`: Install [cfssl](https://github.com/cloudflare/cfssl)
+* `cfssljson`: Install [cfssl](https://github.com/cloudflare/cfssl)
+
+#### ClusterResourceOverride Parameters
+The file `artifacts/configuration.yaml` is copied to `/etc/clusterresourceoverride/config/override.yaml` inside the docker image. If you want to change the parameters then edit the file and rebuild the image.
+```
+apiVersion: v1
+kind: ClusterResourceOverrideConfig
+memoryRequestToLimitPercent: 50
+cpuRequestToLimitPercent: 25
+limitCPUToMemoryPercent: 200
+```
+
+`ClusterResourceOverride` admission webhook server loads the configuration file when it starts. 
+
+#### Build:
+```bash
+make build
+```
+
+Build and push image:
+```bash
+# make local-image IMAGE_REGISTRY={url to repository} IMAGE_TAG={tag}
+make local-image IMAGE_REGISTRY=docker.io/redhat/clusterresourceoverride IMAGE_TAG=dev
+
+make local-push IMAGE_REGISTRY=docker.io/redhat/clusterresourceoverride IMAGE_TAG=dev
+```
+
+#### Deploy
+If you build your own image then edit the `deployment.yaml` file inside `artifacts/manifests` and point to the right `image`.
+```
+    spec:
+      serviceAccountName: clusterresourceoverride
+      containers:
+        - name: clusterresourceoverride
+          image: docker.io/redhat/clusterresourceoverride:dev
+          imagePullPolicy: Always
+
+```  
+
+```bash
+# generate manifests
+make manifests
+
+kubectl apply -f _output/manifests
+```

--- a/artifacts/configuration.yaml
+++ b/artifacts/configuration.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ClusterResourceOverrideConfig
+memoryRequestToLimitPercent: 50
+cpuRequestToLimitPercent: 25
+limitCPUToMemoryPercent: 200

--- a/artifacts/manifests/001_namespace.yaml
+++ b/artifacts/manifests/001_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-resource-override

--- a/artifacts/manifests/002_sa.yaml
+++ b/artifacts/manifests/002_sa.yaml
@@ -1,0 +1,6 @@
+# to be able to assign powers to the process
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: cluster-resource-override
+  name: clusterresourceoverride

--- a/artifacts/manifests/003_rbac.yaml
+++ b/artifacts/manifests/003_rbac.yaml
@@ -1,0 +1,80 @@
+# to delegate authentication and authorization
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: auth-delegator-cluster-resource-override
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    namespace: cluster-resource-override
+    name: clusterresourceoverride
+---
+# to let aggregated apiservers create admission reviews
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:clusterresourceoverride-requester
+rules:
+  - apiGroups:
+      - autoscaling.openshift.io
+    resources:
+      - clusterresourceoverride
+    verbs:
+      - create
+---
+# to read the config for terminating authentication
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: extension-server-authentication-reader-clusterresourceoverride
+roleRef:
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+  name: extension-apiserver-authentication-reader
+subjects:
+  - kind: ServiceAccount
+    namespace: cluster-resource-override
+    name: clusterresourceoverride
+---
+# this should be a default for an aggregated apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: should-be-default-for-aggregated-apiserver
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+# this should be a default for an aggregated apiserver
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: should-be-default-for-aggregated-apiserver
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: should-be-default-for-aggregated-apiserver
+subjects:
+  - kind: ServiceAccount
+    namespace: cluster-resource-override
+    name: clusterresourceoverride
+

--- a/artifacts/manifests/004_secret.yaml
+++ b/artifacts/manifests/004_secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: cluster-resource-override
+  name: server-serving-cert
+type: kubernetes.io/tls
+data:
+  tls.crt: TLS_SERVING_CERT
+  tls.key: TLS_SERVING_KEY

--- a/artifacts/manifests/005_deployment.yaml
+++ b/artifacts/manifests/005_deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: cluster-resource-override
+  name: clusterresourceoverride
+  labels:
+    clusterresourceoverride: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      clusterresourceoverride: "true"
+  template:
+    metadata:
+      name: clusterresourceoverride
+      labels:
+        clusterresourceoverride: "true"
+    spec:
+      serviceAccountName: clusterresourceoverride
+      containers:
+        - name: clusterresourceoverride
+          image: docker.io/tohinkashem/clusterresourceoverride:dev
+          imagePullPolicy: Always
+          args:
+            - "--secure-port=8443"
+            - "--audit-log-path=-"
+            - "--tls-cert-file=/var/serving-cert/tls.crt"
+            - "--tls-private-key-file=/var/serving-cert/tls.key"
+            - "--v=8"
+          env:
+            - name: CONFIGURATION_PATH
+              value: /etc/clusterresourceoverride/config/override.yaml
+          ports:
+            - containerPort: 8443
+          volumeMounts:
+            - mountPath: /var/serving-cert
+              name: serving-cert
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8443
+              scheme: HTTPS
+      volumes:
+        - name: serving-cert
+          secret:
+            defaultMode: 420
+            secretName: server-serving-cert

--- a/artifacts/manifests/006_service.yaml
+++ b/artifacts/manifests/006_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusterresourceoverride
+  namespace: cluster-resource-override
+  labels:
+    clusterresourceoverride: "true"
+spec:
+  selector:
+    clusterresourceoverride: "true"
+  ports:
+    - port: 443
+      targetPort: 8443

--- a/artifacts/manifests/007_apiservice.yaml
+++ b/artifacts/manifests/007_apiservice.yaml
@@ -1,0 +1,23 @@
+# register as aggregated apiserver; this has a number of benefits:
+#
+# - allows other kubernetes components to talk to the the admission webhook using the `kubernetes.default.svc` service
+# - allows other kubernetes components to use their in-cluster credentials to communicate with the webhook
+# - allows you to test the webhook using kubectl
+# - allows you to govern access to the webhook using RBAC
+# - prevents other extension API servers from leaking their service account tokens to the webhook
+#
+# for more information, see: https://kubernetes.io/blog/2018/01/extensible-admission-is-beta
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1.admission.autoscaling.openshift.io
+spec:
+  group: admission.autoscaling.openshift.io
+  version: v1
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: clusterresourceoverride
+    namespace: cluster-resource-override
+  caBundle: SERVICE_SERVING_CERT_CA
+

--- a/artifacts/manifests/008_mutating.yaml
+++ b/artifacts/manifests/008_mutating.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: clusterresourceoverrides.admission.autoscaling.openshift.io
+  labels:
+    clusterresourceoverride: "true"
+webhooks:
+  - name: clusterresourceoverrides.admission.autoscaling.openshift.io
+    clientConfig:
+      service:
+        # reach the webhook via the registered aggregated API
+        namespace: default
+        name: kubernetes
+        path: /apis/admission.autoscaling.openshift.io/v1/clusterresourceoverrides
+      caBundle: KUBE_CA
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - ""
+        apiVersions:
+          - "v1"
+        resources:
+          - "pods"
+    failurePolicy: Fail

--- a/artifacts/sample/deployment.yaml
+++ b/artifacts/sample/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "2000m"

--- a/artifacts/sample/request.yaml
+++ b/artifacts/sample/request.yaml
@@ -1,0 +1,20 @@
+apiVersion: admission.k8s.io/v1beta1
+kind: AdmissionReview
+request:
+  kind:
+    group:
+    kind: Pod
+    version: v1
+  resource:
+    group:
+    version: v1
+    resource: pods
+  object:
+    metadata:
+      name: myapp
+    spec:
+      containers:
+        - image: nginx
+          name: nginx-frontend
+        - image: mysql
+          name: mysql-backend

--- a/hack/generate-cert.sh
+++ b/hack/generate-cert.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -e
+
+# creates a client CA, args are sudo, dest-dir, ca-id, purpose
+# purpose is dropped in after "key encipherment", you usually want
+# '"client auth"'
+# '"server auth"'
+# '"client auth","server auth"'
+function kube::util::create_signing_certkey {
+    local sudo=$1
+    local dest_dir=$2
+    local id=$3
+    local purpose=$4
+    # Create client ca
+    ${sudo} /bin/bash -e <<EOF
+    rm -f "${dest_dir}/${id}-ca.crt" "${dest_dir}/${id}-ca.key"
+    openssl req -x509 -sha256 -new -nodes -days 365 -newkey rsa:2048 -keyout "${dest_dir}/${id}-ca.key" -out "${dest_dir}/${id}-ca.crt" -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=ca/emailAddress=x/"
+    echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment",${purpose}]}}}' > "${dest_dir}/${id}-ca-config.json"
+EOF
+}
+
+# signs a serving certificate: args are sudo, dest-dir, ca, filename (roughly), subject, hosts...
+function kube::util::create_serving_certkey {
+    local sudo=$1
+    local dest_dir=$2
+    local ca=$3
+    local id=$4
+    local cn=${5:-$4}
+    local hosts=""
+    local SEP=""
+    shift 5
+    while [ -n "${1:-}" ]; do
+        hosts+="${SEP}\"$1\""
+        SEP=","
+        shift 1
+    done
+    ${sudo} /bin/bash -e <<EOF
+    cd ${dest_dir}
+    echo '{"CN":"${cn}","hosts":[${hosts}],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=${ca}.crt -ca-key=${ca}.key -config=${ca}-config.json - | cfssljson -bare serving-${id}
+    mv "serving-${id}-key.pem" "serving-${id}.key"
+    mv "serving-${id}.pem" "serving-${id}.crt"
+    rm -f "serving-${id}.csr"
+EOF
+}
+
+which jq &>/dev/null || { echo "Please install jq (https://stedolan.github.io/jq/)."; exit 1; }
+which cfssl &>/dev/null || { echo "Please install cfssl (https://github.com/cloudflare/cfssl))."; exit 1; }
+which cfssljson &>/dev/null || { echo "Please install cfssljson (https://github.com/cloudflare/cfssl))."; exit 1; }
+
+CERT_FILE_PATH=$1
+if [ "${CERT_FILE_PATH}" == "" ]; then
+  echo "Must specify a file path to store the certs"
+  exit 1
+fi
+
+kubectl config current-context || { echo "Set a context (kubectl use-context <context>) out of the following:"; echo; kubectl config get-contexts; exit 1; }
+
+# create necessary TLS certificates:
+# - a local CA key and cert
+# - a webhook server key and cert signed by the local CA
+CERT_DIR=_output/certs
+rm -rf "${CERT_DIR}"
+mkdir -p "${CERT_DIR}"
+kube::util::create_signing_certkey "" "${CERT_DIR}" serving '"server auth"'
+
+# create webhook server key and cert
+kube::util::create_serving_certkey "" "${CERT_DIR}" "serving-ca" clusterresourceoverride.cluster-resource-override.svc "clusterresourceoverride.cluster-resource-override.svc" "clusterresourceoverride.cluster-resource-override.svc"
+
+KUBE_CA=$(kubectl config view --minify=true --flatten -o json | jq '.clusters[0].cluster."certificate-authority-data"' -r)
+TLS_SERVING_CERT=$(base64 ${CERT_DIR}/serving-clusterresourceoverride.cluster-resource-override.svc.crt | tr -d '\n')
+TLS_SERVING_KEY=$(base64 ${CERT_DIR}/serving-clusterresourceoverride.cluster-resource-override.svc.key | tr -d '\n')
+SERVICE_SERVING_CERT_CA=$(base64 ${CERT_DIR}/serving-ca.crt | tr -d '\n')
+
+cat <<EOF > ${CERT_FILE_PATH}
+{
+  "kube.ca": "${KUBE_CA}",
+  "tls.serving.key": "${TLS_SERVING_KEY}",
+  "tls.serving.cert": "${TLS_SERVING_CERT}",
+  "service.serving.cert.ca": "${SERVICE_SERVING_CERT_CA}"
+}
+EOF

--- a/hack/load-cert-into-manifest.sh
+++ b/hack/load-cert-into-manifest.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+which jq &>/dev/null || { echo "Please install jq (https://stedolan.github.io/jq/)."; exit 1; }
+
+CERT_FILE_PATH=$1
+if [ "${CERT_FILE_PATH}" == "" ]; then
+  echo "Must specify a file path to the file that has the keys/certs"
+  exit 1
+fi
+
+MANIFEST_SECRET_YAML=$2
+if [ "${MANIFEST_SECRET_YAML}" == "" ]; then
+  echo "Must specify a path to the yaml file for Secret object"
+  exit 1
+fi
+
+MANIFEST_APISERVICE_YAML=$3
+if [ "${MANIFEST_APISERVICE_YAML}" == "" ]; then
+  echo "Must specify a path to the yaml file for APIService object"
+  exit 1
+fi
+
+MANIFEST_MUTATING_WEBHOOK_YAML=$4
+if [ "${MANIFEST_MUTATING_WEBHOOK_YAML}" == "" ]; then
+  echo "Must specify a path to the yaml file for MutatingWebhookConfiguration object"
+  exit 1
+fi
+
+KUBE_CA=$(cat ${CERT_FILE_PATH} | jq '."kube.ca"')
+TLS_SERVING_CERT=$(cat ${CERT_FILE_PATH} | jq '."tls.serving.cert"')
+TLS_SERVING_KEY=$(cat ${CERT_FILE_PATH} | jq '."tls.serving.key"')
+SERVICE_SERVING_CERT_CA=$(cat ${CERT_FILE_PATH} | jq '."service.serving.cert.ca"')
+
+sed "s/TLS_SERVING_CERT/${TLS_SERVING_CERT}/g" -i "${MANIFEST_SECRET_YAML}"
+sed "s/TLS_SERVING_KEY/${TLS_SERVING_KEY}/g" -i "${MANIFEST_SECRET_YAML}"
+
+sed "s/SERVICE_SERVING_CERT_CA/${SERVICE_SERVING_CERT_CA}/g" -i "${MANIFEST_APISERVICE_YAML}"
+sed "s/KUBE_CA/${KUBE_CA}/g" -i "${MANIFEST_MUTATING_WEBHOOK_YAML}"

--- a/images/dev/Dockerfile.dev
+++ b/images/dev/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM centos:7
+
+ADD artifacts/configuration.yaml /etc/clusterresourceoverride/config/override.yaml
+ADD bin/cluster-resource-override-admission /usr/bin
+
+ENV CONFIGURATION_PATH=/etc/clusterresourceoverride/config/override.yaml
+
+ENTRYPOINT ["/usr/bin/cluster-resource-override-admission"]


### PR DESCRIPTION
- Write script to generate certs.
- Add kubernetes yaml manifests that deploy the admission webhook.
- Write a script that populates the Secret, APIService and
  MutatingWebhookConfiguration with proper certs.
- Add goal to Makefile to generate ready to deploy manifests.
- Update README