### PR TITLE
Fix Dockerfile.dev

### DIFF
--- a/artifacts/manifests/500_deployment.yaml
+++ b/artifacts/manifests/500_deployment.yaml
@@ -23,6 +23,8 @@ spec:
         - name: clusterresourceoverride
           image: docker.io/tohinkashem/clusterresourceoverride:dev
           imagePullPolicy: Always
+          command:
+            - /usr/bin/cluster-resource-override-admission
           args:
             - "--secure-port=9400"
             - "--bind-address=127.0.0.1"

--- a/images/dev/Dockerfile.dev
+++ b/images/dev/Dockerfile.dev
@@ -5,4 +5,3 @@ ADD bin/cluster-resource-override-admission /usr/bin
 
 ENV CONFIGURATION_PATH=/etc/clusterresourceoverride/config/override.yaml
 
-ENTRYPOINT ["/usr/bin/cluster-resource-override-admission"]


### PR DESCRIPTION
- To keep it consistent remove ENTRYPOINT from Dockerfile.dev
  and invoke the binary using 'command'.