### PR TITLE
Bug 1801848: Overridden quantity must be below namespace Maximum

### DIFF
--- a/artifacts/manifests/300_rbac.yaml
+++ b/artifacts/manifests/300_rbac.yaml
@@ -59,6 +59,7 @@ rules:
       - ""
     resources:
       - namespaces
+      - limitranges
     verbs:
       - get
       - list

--- a/artifacts/manifests/600_mutating.yaml
+++ b/artifacts/manifests/600_mutating.yaml
@@ -31,3 +31,4 @@ webhooks:
     failurePolicy: Fail
     timeoutSeconds: 5
     sideEffects: None
+    reinvocationPolicy: IfNeeded

--- a/pkg/clusterresourceoverride/admission_test.go
+++ b/pkg/clusterresourceoverride/admission_test.go
@@ -15,7 +15,7 @@ func TestSetNamespaceFloor(t *testing.T) {
 	memory := resource.MustParse("1Gi")
 	require.False(t, memory.Equal(defaultMemoryFloor), "bad test setup, default and namespace memory floor must not be equal")
 
-	namespaceFloor := &Floor{
+	namespaceFloor := &CPUMemory{
 		CPU:    &cpu,
 		Memory: &memory,
 	}

--- a/pkg/clusterresourceoverride/limitquerier.go
+++ b/pkg/clusterresourceoverride/limitquerier.go
@@ -13,55 +13,91 @@ type namespaceLimitQuerier struct {
 	limitRangesLister corev1listers.LimitRangeLister
 }
 
-func (l *namespaceLimitQuerier) QueryMinimum(namespace string) (minimum *Floor, err error) {
-	limits, listErr := l.limitRangesLister.LimitRanges(namespace).List(labels.Everything())
+func (l *namespaceLimitQuerier) QueryFloorAndCeiling(namespace string) (floor *CPUMemory, ceiling *CPUMemory, err error) {
+	limitRanges, listErr := l.limitRangesLister.LimitRanges(namespace).List(labels.Everything())
 	if listErr != nil {
 		err = fmt.Errorf("failed to query limitrange - %v", listErr)
 		return
 	}
 
-	nsCPUFloor := minResourceLimits(limits, corev1.ResourceCPU)
-	nsMemFloor := minResourceLimits(limits, corev1.ResourceMemory)
+	nsCPUMinimum, nsCPUMaximum := GetMinMax(limitRanges, corev1.ResourceCPU)
+	nsMemMinimum, nsMemMaximum := GetMinMax(limitRanges, corev1.ResourceMemory)
 
-	minimum = &Floor{
-		CPU:    nsCPUFloor,
-		Memory: nsMemFloor,
+	floor = &CPUMemory{
+		CPU:    nsCPUMinimum,
+		Memory: nsMemMinimum,
+	}
+	ceiling = &CPUMemory{
+		CPU:    nsCPUMaximum,
+		Memory: nsMemMaximum,
 	}
 	return
 }
 
-// minResourceLimits finds the Min limit for resourceName. Nil is
-// returned if limitRanges is empty or limits contains no resourceName
-// limits.
-func minResourceLimits(limitRanges []*corev1.LimitRange, resourceName corev1.ResourceName) *resource.Quantity {
-	limits := []*resource.Quantity{}
+// GetMinMax finds the Minimum and Maximum limit for respectively for the specified resource.
+// Nil is returned if limitRanges is empty or limits contains no resourceName limits.
+func GetMinMax(limitRanges []*corev1.LimitRange, resourceName corev1.ResourceName) (minimum *resource.Quantity, maximum *resource.Quantity) {
+	minList, maxList := findMinMaxLimits(limitRanges, resourceName)
+
+	minimum = minQuantity(minList)
+	maximum = maxQuantity(maxList)
+
+	return
+}
+
+func findMinMaxLimits(limitRanges []*corev1.LimitRange, resourceName corev1.ResourceName) (minimum []*resource.Quantity, maximum []*resource.Quantity) {
+	minimum = []*resource.Quantity{}
+	maximum = []*resource.Quantity{}
 
 	for _, limitRange := range limitRanges {
-		for _, limit := range limitRange.Spec.Limits {
-			if limit.Type == corev1.LimitTypeContainer {
-				if limit, found := limit.Min[resourceName]; found {
-					clone := limit.DeepCopy()
-					limits = append(limits, &clone)
+		for _, limits := range limitRange.Spec.Limits {
+			if limits.Type == corev1.LimitTypeContainer {
+				if min, found := limits.Min[resourceName]; found {
+					clone := min.DeepCopy()
+					minimum = append(minimum, &clone)
+				}
+
+				if max, found := limits.Max[resourceName]; found {
+					clone := max.DeepCopy()
+					maximum = append(maximum, &clone)
 				}
 			}
 		}
 	}
 
-	if len(limits) == 0 {
-		return nil
-	}
-
-	return minQuantity(limits)
+	return
 }
 
 func minQuantity(quantities []*resource.Quantity) *resource.Quantity {
-	min := quantities[0].DeepCopy()
+	if len(quantities) == 0 {
+		return nil
+	}
+
+	min := *quantities[0]
 
 	for i := range quantities {
 		if quantities[i].Cmp(min) < 0 {
-			min = quantities[i].DeepCopy()
+			min = *quantities[i]
 		}
 	}
 
-	return &min
+	copy := min.DeepCopy()
+	return &copy
+}
+
+func maxQuantity(quantities []*resource.Quantity) *resource.Quantity {
+	if len(quantities) == 0 {
+		return nil
+	}
+
+	max := *quantities[0]
+
+	for i := range quantities {
+		if quantities[i].Cmp(max) > 0 {
+			max = *quantities[i]
+		}
+	}
+
+	copy := max.DeepCopy()
+	return &copy
 }

--- a/pkg/clusterresourceoverride/limitquerier_test.go
+++ b/pkg/clusterresourceoverride/limitquerier_test.go
@@ -1,0 +1,81 @@
+package clusterresourceoverride
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMinMax(t *testing.T) {
+	tests := []struct {
+		name         string
+		limitRanges  []*corev1.LimitRange
+		resourceName corev1.ResourceName
+		minimumWant  resource.Quantity
+		maximumWant  resource.Quantity
+	}{
+		{
+			name: "WithMaximumCPULimit",
+			limitRanges: []*corev1.LimitRange{
+				{
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypeContainer,
+								Max: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("1024Mi"),
+									corev1.ResourceCPU:    resource.MustParse("1000m"),
+								},
+								Min: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			resourceName: corev1.ResourceCPU,
+			maximumWant:  resource.MustParse("1000m"),
+			minimumWant:  resource.MustParse("100m"),
+		},
+
+		{
+			name: "WithMaximumMemoryLimit",
+			limitRanges: []*corev1.LimitRange{
+				{
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypeContainer,
+								Max: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("1024Mi"),
+									corev1.ResourceCPU:    resource.MustParse("1000m"),
+								},
+								Min: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			resourceName: corev1.ResourceMemory,
+			maximumWant:  resource.MustParse("1024Mi"),
+			minimumWant:  resource.MustParse("128Mi"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			minimumGot, maximumGot := GetMinMax(test.limitRanges, test.resourceName)
+
+			assert.True(t, test.minimumWant.Equal(*minimumGot))
+			assert.True(t, test.maximumWant.Equal(*maximumGot))
+		})
+	}
+}

--- a/pkg/clusterresourceoverride/mutator_test.go
+++ b/pkg/clusterresourceoverride/mutator_test.go
@@ -16,7 +16,7 @@ const (
 func TestMutator_Mutate(t *testing.T) {
 	cpu := resource.MustParse("1m")
 	memory := resource.MustParse("1Mi")
-	floor := &Floor{
+	floor := &CPUMemory{
 		CPU:    &cpu,
 		Memory: &memory,
 	}
@@ -25,7 +25,7 @@ func TestMutator_Mutate(t *testing.T) {
 		CpuRequestToLimitRatio:    0.25,
 		MemoryRequestToLimitRatio: 0.5,
 	}
-	mutator, err := NewMutator(config, floor, factor)
+	mutator, err := NewMutator(config, floor, &CPUMemory{}, factor)
 	require.NoError(t, err)
 	require.NotNil(t, mutator)
 
@@ -168,7 +168,7 @@ func TestMutator_OverrideMemory(t *testing.T) {
 					config: &Config{
 						MemoryRequestToLimitRatio: 0.5,
 					},
-					floor: &Floor{
+					floor: &CPUMemory{
 						Memory: func() *resource.Quantity {
 							q := resource.MustParse("4Gi")
 							return &q
@@ -280,7 +280,7 @@ func TestMutator_OverrideCpu(t *testing.T) {
 					config: &Config{
 						CpuRequestToLimitRatio: 0.10,
 					},
-					floor: &Floor{
+					floor: &CPUMemory{
 						CPU: func() *resource.Quantity {
 							q := resource.MustParse("250m")
 							return &q
@@ -381,7 +381,7 @@ func TestMutator_OverrideCPULimit(t *testing.T) {
 					config: &Config{
 						LimitCPUToMemoryRatio: 0.5,
 					},
-					floor: &Floor{
+					floor: &CPUMemory{
 						CPU: func() *resource.Quantity {
 							q := resource.MustParse("1000m")
 							return &q


### PR DESCRIPTION
The overridden quantity must be below the namespace Maximum specified
via LimitRange object.

Currently the mutating admission webhook overrides a resource above
the namespace maximum and thus fails Pod creation, we see the
following error:
"pods "croe2e-f7c9h" is forbidden: maximum cpu usage per Container is 1, but limit is 2"

Query the Maximum limit for CPU and Memory resource specified in
LimitRange and ensure that the overridden resource quantity never
exceeds the namespace Maximum.