### PR TITLE
Updating clusterresourceoverride builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission
 COPY . .
 RUN make build
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 
 LABEL io.k8s.display-name="OpenShift ClusterResourceOverride Admission Webhook" \
       io.k8s.description="Manages level of overcommit of Pod Resource(s)" \


### PR DESCRIPTION
Updating clusterresourceoverride builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/clusterresourceoverride.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.