### PR TITLE
Bug 1920756: update generic-admission-server library to get the system:masters authorization optimization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/imdario/mergo v0.3.8 // indirect
-	github.com/openshift/generic-admission-server v1.14.1-0.20210121183534-8cbb259223ad
+	github.com/openshift/generic-admission-server v1.14.1-0.20210126171102-c9c786658775
 	github.com/openshift/library-go v0.0.0-20191112181215-0597a29991ca
 	github.com/stretchr/testify v1.4.0
 	gomodules.xyz/jsonpatch/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/openshift/generic-admission-server v1.14.1-0.20210121183534-8cbb259223ad h1:x1kC5QBN+9nibULnM4EodHwh6k6AXYKRmxic9h9sbk0=
-github.com/openshift/generic-admission-server v1.14.1-0.20210121183534-8cbb259223ad/go.mod h1:m+wYlVQdnPe8JGqoKVpCYnFRIVraqC1SrUowQXh6XlA=
+github.com/openshift/generic-admission-server v1.14.1-0.20210126171102-c9c786658775 h1:0oP2Va4ukEMkiutgO0a9Aj/UyIXPxSSsAtjWqrbwW6k=
+github.com/openshift/generic-admission-server v1.14.1-0.20210126171102-c9c786658775/go.mod h1:m+wYlVQdnPe8JGqoKVpCYnFRIVraqC1SrUowQXh6XlA=
 github.com/openshift/library-go v0.0.0-20191112181215-0597a29991ca h1:na+aH2m/OfMUzlh3l757OOPruejkk+Q0dBhI63v6B1o=
 github.com/openshift/library-go v0.0.0-20191112181215-0597a29991ca/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openshift/generic-admission-server/pkg/cmd/server/start.go
+++ b/vendor/github.com/openshift/generic-admission-server/pkg/cmd/server/start.go
@@ -41,6 +41,13 @@ func NewAdmissionServerOptions(out, errOut io.Writer, admissionHooks ...apiserve
 	o.RecommendedOptions.Etcd = nil
 	o.RecommendedOptions.Admission = nil
 
+	// we can also optimize the authz options.  We know that system:masters should always be authorized for actions and the
+	// delegating authorizer now allows this.
+	o.RecommendedOptions.Authorization = o.RecommendedOptions.Authorization.
+		WithAlwaysAllowPaths("/healthz", "/readyz", "/livez"). // this allows the kubelet to always get health and readiness without causing an access check
+		WithAlwaysAllowGroups("system:masters") // in a kube cluster, system:masters can take any action, so there is no need to ask for an authz check
+
+
 	return o
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 github.com/munnerz/goautoneg
-# github.com/openshift/generic-admission-server v1.14.1-0.20210121183534-8cbb259223ad
+# github.com/openshift/generic-admission-server v1.14.1-0.20210126171102-c9c786658775
 github.com/openshift/generic-admission-server/pkg/apiserver
 github.com/openshift/generic-admission-server/pkg/cmd
 github.com/openshift/generic-admission-server/pkg/cmd/server


### PR DESCRIPTION
pulls in https://github.com/openshift/generic-admission-server/pull/39

manually verified the efficacy of the peer change in https://github.com/openshift/library-go/pull/983