### PR TITLE
OCPBUGS-15332: Prevent mutation attempts that can't ever succeed

### DIFF
--- a/pkg/clusterresourceoverride/admission.go
+++ b/pkg/clusterresourceoverride/admission.go
@@ -175,8 +175,7 @@ func (p *clusterResourceOverrideAdmission) GetConfiguration() *Config {
 
 func (p *clusterResourceOverrideAdmission) IsApplicable(request *admissionv1.AdmissionRequest) bool {
 	if request.Resource.Resource == string(corev1.ResourcePods) &&
-		request.SubResource == "" &&
-		(request.Operation == admissionv1.Create || request.Operation == admissionv1.Update) {
+		request.SubResource == "" && request.Operation == admissionv1.Create {
 
 		return true
 	}


### PR DESCRIPTION
There were some corner cases specifically around UPDATE requests for pods that were:
- present before resource override was enabled on a namespace
- present when the `ClusterResourceOverride` policy changed

For pods in such circumstances:
- we would still attempt to update the resources (or selinux relabel, since that's in here too) 
- our patch would ultimately fail validation for modifying fields that could not be modified
- that effectively blocked any Pod updates (by anyone, especially finalizations) from succeeding 

To address that, this PR:
- prevents UPDATE requests from patching pods/containers by regarding updates as "NotApplicable" for now

(I previously had logic in here to allow for `InPlacePodVerticalScaling`, but that's not easily backportable so I'll re-enable UPDATES for 4.14+ and do that in a separate PR that I will link here) 


Fixes: [OCPBUGS-15332](https://issues.redhat.com/browse/OCPBUGS-15332)