### PR TITLE
PODAUTO-202: Update ocp/builder to openshift/release images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ CERT_FILE_PATH := "$(OUTPUT_DIR)/certs.yaml"
 MANIFEST_SECRET_YAML := "$(MANIFEST_DIR)/400_secret.yaml"
 MANIFEST_MUTATING_WEBHOOK_YAML := "$(MANIFEST_DIR)/600_mutating.yaml"
 
+CONTAINER_ENGINE ?= podman
+IMAGE_BUILDER ?= $(CONTAINER_ENGINE)
+
+IMAGE_VERSION ?= dev
+IMAGE_TAG_BASE ?= quay.io/redhat/clusterresourceoverride
+LOCAL_OPERAND_IMAGE ?= $(IMAGE_TAG_BASE):$(IMAGE_VERSION)
+
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \
@@ -23,10 +30,10 @@ $(call build-image,cluster-resource-override-admission,$(CI_IMAGE_REGISTRY)/auto
 
 # build image for dev use.
 local-image:
-	docker build -t $(LOCAL_IMAGE_REGISTRY):$(IMAGE_TAG) -f ./images/dev/Dockerfile.dev .
+	$(IMAGE_BUILDER) build -t $(LOCAL_OPERAND_IMAGE) -f ./images/dev/Dockerfile.dev .
 
 local-push:
-	docker push $(LOCAL_IMAGE_REGISTRY):$(IMAGE_TAG)
+	$(IMAGE_BUILDER) push $(LOCAL_OPERAND_IMAGE)
 
 # generate manifests for installing on a dev cluster.
 manifests:

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@
 ## Developer Workflow
 ### Deploy
 #### Prerequisites:
-* `go`: `1.12` or above
+* `go`: `1.22` or above
 * `jq`: Install [jq](https://stedolan.github.io/jq)
 * `cfssl`: Install [cfssl](https://github.com/cloudflare/cfssl)
 * `cfssljson`: Install [cfssl](https://github.com/cloudflare/cfssl)
+* `podman`: Install [podman](https://podman.io/docs/installation)
+  - Alternatively [docker](https://docs.docker.com/engine/install/) or [buildah](https://github.com/containers/buildah/blob/main/install.md)+`
+* `kubectl` or `oc` Install from either
+  * [OpenShift](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html)
+  * [Kubernetes](https://kubernetes.io/docs/reference/kubectl/)
+
+
+`ClusterResourceOverride` Admission Webhook Operator is located at [cluster-resource-override-admission-operator](https://github.com/openshift/cluster-resource-override-admission-operator).
 
 #### ClusterResourceOverride Parameters
 The file `artifacts/configuration.yaml` is copied to `/etc/clusterresourceoverride/config/override.yaml` inside the docker image. If you want to change the parameters then edit the file and rebuild the image.
@@ -29,10 +37,11 @@ make build
 
 Build and push image:
 ```bash
-# make local-image LOCAL_IMAGE_REGISTRY={url to repository} IMAGE_TAG={tag}
-make local-image LOCAL_IMAGE_REGISTRY=docker.io/redhat/clusterresourceoverride IMAGE_TAG=dev
+# make local-image DEV_IMAGE_REGISTRY={url to repository} IMAGE_TAG={tag}
+# Specify your image builder with IMAGE_BUILDER=podman|docker|buildah. Defaults to podman.
+make local-image IMAGE_TAG_BASE=docker.io/redhat/clusterresourceoverride IMAGE_VERSION=dev
 
-make local-push LOCAL_IMAGE_REGISTRY=docker.io/redhat/clusterresourceoverride IMAGE_TAG=dev
+make local-push IMAGE_TAG_BASE=docker.io/redhat/clusterresourceoverride IMAGE_VERSION=dev
 ```
 
 #### Deploy

--- a/images/ci/Dockerfile
+++ b/images/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-resource-override-admission
 COPY . .
 RUN make build

--- a/images/dev/Dockerfile.dev
+++ b/images/dev/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi9-minimal:9.4
 
 ADD artifacts/configuration.yaml /etc/clusterresourceoverride/config/override.yaml
 ADD bin/cluster-resource-override-admission /usr/bin


### PR DESCRIPTION
Did not update `Dockerfile.rhel7` because ART does not support it yet.
Updated `Makefile` to support other builders like buildah and podman.
Updated `images/ci/Dockerfile` for consistency on the ci side.
Updated `images/dev/Dockerfile.dev` from deprecated `centos` to `ubi9-minimal` image
Updated README.md for documentation purposes.