### PR TITLE
[release-4.13] OCPBUGS-42673: Fix klogv2 flags not being initialized

### DIFF
--- a/cmd/cluster-resource-override-admission/main.go
+++ b/cmd/cluster-resource-override-admission/main.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	"github.com/openshift/generic-admission-server/pkg/cmd"
+	"k8s.io/klog/v2"
 )
 
 func main() {
+	// jkyros: This is present only in 4.13 because the generic-admission-server switched to klogv2, and
+	// the only version of generic-admission-server we have that's compatible with our kube 1.26.1 deps
+	// doesn't initialize the flags right, so we initialize them here first so they aren't "unknown" and
+	// won't cause the pod to crash.
+	klog.InitFlags(nil)
 	cmd.RunAdmissionServer(&clusterResourceOverrideHook{})
 }


### PR DESCRIPTION
The generic-admission-server we bumped to as part of https://github.com/openshift/cluster-resource-override-admission/pull/79 apparently doesn't init the log flags right, so we have to do it ourselves. 

This gets fixed in later versions, which we can't move to because they're not compatible with our kube 1.26.1 deps, so we're just going to init them ourselves in 4.13 to prevent pods from crashing/erroring. 


Fixes: [OCPBUGS-42673](https://issues.redhat.com/browse/OCPBUGS-42673)