### PR TITLE
AUTOSCALE-705: Add cpuRequestToRequestPercent override field for CPU request scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ spec:
   memoryRequestToLimitPercent: 50
   cpuRequestToLimitPercent: 25
   limitCPUToMemoryPercent: 200
+  cpuRequestToRequestPercent: 25
 ```
 
 `ClusterResourceOverride` admission webhook server loads the configuration file when it starts. 

--- a/pkg/clusterresourceoverride/config.go
+++ b/pkg/clusterresourceoverride/config.go
@@ -34,6 +34,10 @@ type ClusterResourceOverrideSpec struct {
 
 	// MemoryRequestToLimitPercent (if > 0) overrides memory request to a percentage of memory limit
 	MemoryRequestToLimitPercent int64 `json:"memoryRequestToLimitPercent"`
+
+	// CPURequestToRequestPercent (if > 0) overrides CPU request to a percentage of the
+	// existing CPU request.
+	CPURequestToRequestPercent int64 `json:"cpuRequestToRequestPercent"`
 }
 
 type Config struct {
@@ -41,11 +45,12 @@ type Config struct {
 	LimitCPUToMemoryRatio     float64
 	CpuRequestToLimitRatio    float64
 	MemoryRequestToLimitRatio float64
+	CpuRequestToRequestRatio  float64
 }
 
 func (c *Config) String() string {
-	return fmt.Sprintf("LimitCPUToMemoryRatio=%f CpuRequestToLimitRatio=%f MemoryRequestToLimitRatio=%f ForceSelinuxRelabel=%v",
-		c.LimitCPUToMemoryRatio, c.CpuRequestToLimitRatio, c.MemoryRequestToLimitRatio, c.ForceSelinuxRelabel)
+	return fmt.Sprintf("LimitCPUToMemoryRatio=%f CpuRequestToLimitRatio=%f MemoryRequestToLimitRatio=%f CpuRequestToRequestRatio=%f ForceSelinuxRelabel=%v",
+		c.LimitCPUToMemoryRatio, c.CpuRequestToLimitRatio, c.MemoryRequestToLimitRatio, c.CpuRequestToRequestRatio, c.ForceSelinuxRelabel)
 }
 
 func ConvertExternalConfig(object *ClusterResourceOverride) *Config {
@@ -54,6 +59,7 @@ func ConvertExternalConfig(object *ClusterResourceOverride) *Config {
 		LimitCPUToMemoryRatio:     float64(object.Spec.LimitCPUToMemoryPercent) / 100,
 		CpuRequestToLimitRatio:    float64(object.Spec.CPURequestToLimitPercent) / 100,
 		MemoryRequestToLimitRatio: float64(object.Spec.MemoryRequestToLimitPercent) / 100,
+		CpuRequestToRequestRatio:  float64(object.Spec.CPURequestToRequestPercent) / 100,
 	}
 }
 
@@ -73,10 +79,15 @@ func Decode(reader io.Reader) (object *ClusterResourceOverride, err error) {
 
 func DecodeWithFile(path string) (object *ClusterResourceOverride, err error) {
 	reader, openErr := os.Open(path)
-	if err != nil {
+	if openErr != nil {
 		err = fmt.Errorf("unable to load file %s: %s", path, openErr)
 		return
 	}
+	defer func() {
+		if closeErr := reader.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("unable to close file %s: %w", path, closeErr)
+		}
+	}()
 
 	object, err = Decode(reader)
 	return

--- a/pkg/clusterresourceoverride/config_test.go
+++ b/pkg/clusterresourceoverride/config_test.go
@@ -12,6 +12,7 @@ func TestConvertExternalConfig(t *testing.T) {
 			LimitCPUToMemoryPercent:     400,
 			CPURequestToLimitPercent:    25,
 			MemoryRequestToLimitPercent: 50,
+			CPURequestToRequestPercent:  25,
 		},
 	}
 
@@ -20,6 +21,7 @@ func TestConvertExternalConfig(t *testing.T) {
 	assert.Equal(t, 4.0, configGot.LimitCPUToMemoryRatio)
 	assert.Equal(t, 0.25, configGot.CpuRequestToLimitRatio)
 	assert.Equal(t, 0.50, configGot.MemoryRequestToLimitRatio)
+	assert.Equal(t, 0.25, configGot.CpuRequestToRequestRatio)
 }
 
 func TestDecodeWithFile(t *testing.T) {
@@ -38,6 +40,7 @@ func TestDecodeWithFile(t *testing.T) {
 				assert.Equal(t, int64(25), objGot.Spec.MemoryRequestToLimitPercent)
 				assert.Equal(t, int64(50), objGot.Spec.CPURequestToLimitPercent)
 				assert.Equal(t, int64(200), objGot.Spec.LimitCPUToMemoryPercent)
+				assert.Equal(t, int64(25), objGot.Spec.CPURequestToRequestPercent)
 			},
 		},
 	}

--- a/pkg/clusterresourceoverride/mutator.go
+++ b/pkg/clusterresourceoverride/mutator.go
@@ -44,11 +44,11 @@ func (m *podMutator) Mutate(in *corev1.Pod) (out *corev1.Pod, err error) {
 	}
 
 	for i := range current.Spec.InitContainers {
-		m.Override(&current.Spec.InitContainers[i])
+		m.Override(&current.Spec.InitContainers[i], current)
 	}
 
 	for i := range current.Spec.Containers {
-		m.Override(&current.Spec.Containers[i])
+		m.Override(&current.Spec.Containers[i], current)
 	}
 
 	out = current
@@ -56,9 +56,10 @@ func (m *podMutator) Mutate(in *corev1.Pod) (out *corev1.Pod, err error) {
 }
 
 const (
-	SpcType                = "spc_t"
-	SelinuxRelabelResource = "forceselinuxrelabel"
-	SelinuxRelabelGroup    = "admission.node.openshift.io"
+	SpcType                      = "spc_t"
+	SelinuxRelabelResource       = "forceselinuxrelabel"
+	SelinuxRelabelGroup          = "admission.node.openshift.io"
+	OriginalCPURequestAnnotation = "clusterresourceoverrides.admission.autoscaling.openshift.io/original-cpu-request"
 )
 
 var (
@@ -90,13 +91,42 @@ func (m *podMutator) OverrideForceSelinuxRelabel(pod *corev1.Pod) {
 	pod.Spec.SecurityContext.SELinuxOptions = &corev1.SELinuxOptions{Type: SpcType}
 }
 
-func (m *podMutator) Override(container *corev1.Container) {
+func (m *podMutator) Override(container *corev1.Container, current *corev1.Pod) {
+	// Needs to run before an override modifies the request
+	m.AnnotateOriginalRequest(&container.Resources, container.Name, current)
+
 	m.OverrideMemory(&container.Resources)
 
 	// The order is important here, this is processed prior to overriding CPU request.
 	m.OverrideCPULimit(&container.Resources)
 
-	m.OverrideCPU(&container.Resources)
+	m.OverrideCPUWithLimit(&container.Resources)
+
+	// Should run after OverrideCPUWithLimit
+	m.OverrideCPUWithRequest(&container.Resources, container.Name, current)
+}
+
+// Annotates pod with original CPU request value. Annotation provides idempotency for
+// OverrideCPUWithRequest in case of reinvocation. Also preserves original value in case
+// of OverrideCPUWithLimit modifying the request prior to OverrideCPUWithRequest.
+func (m *podMutator) AnnotateOriginalRequest(resources *corev1.ResourceRequirements, name string, pod *corev1.Pod) {
+	if m.config.CpuRequestToRequestRatio == 0 {
+		return
+	}
+
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+
+	key := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, name)
+	_, found := pod.Annotations[key]
+	if !found {
+		request := resources.Requests[corev1.ResourceCPU]
+		if request.IsZero() {
+			return
+		}
+		pod.Annotations[key] = request.String()
+	}
 }
 
 // If a container memory limit has been specified or defaulted, the memory request
@@ -182,7 +212,7 @@ func (m *podMutator) OverrideCPULimit(resources *corev1.ResourceRequirements) {
 
 // If a container CPU limit has been specified or defaulted, the CPU request is
 // overridden to this percentage of the limit.
-func (m *podMutator) OverrideCPU(resources *corev1.ResourceRequirements) {
+func (m *podMutator) OverrideCPUWithLimit(resources *corev1.ResourceRequirements) {
 	limit, found := resources.Limits[corev1.ResourceCPU]
 	if !found {
 		return
@@ -196,13 +226,56 @@ func (m *podMutator) OverrideCPU(resources *corev1.ResourceRequirements) {
 	overridden := resource.NewMilliQuantity(int64(amount), limit.Format)
 
 	if m.IsCpuFloorSpecified() && overridden.Cmp(*m.floor.CPU) < 0 {
-		klog.V(5).Infof("%s pod limit %q below namespace limit; setting limit to %q", corev1.ResourceCPU, overridden.String(), m.floor.CPU.String())
+		klog.V(5).Infof("%s pod request %q below namespace minimum; setting request to %q", corev1.ResourceCPU, overridden.String(), m.floor.CPU.String())
 		clone := m.floor.CPU.DeepCopy()
 		overridden = &clone
 	}
 
 	if m.IsCpuCeilingSpecified() && overridden.Cmp(*m.ceiling.CPU) > 0 {
-		klog.V(5).Infof("%s pod limit %q above namespace limit; setting limit to %q", corev1.ResourceCPU, overridden.String(), m.ceiling.CPU.String())
+		klog.V(5).Infof("%s pod request %q above namespace maximum; setting request to %q", corev1.ResourceCPU, overridden.String(), m.ceiling.CPU.String())
+		clone := m.ceiling.CPU.DeepCopy()
+		overridden = &clone
+	}
+
+	ensureRequests(resources)
+	resources.Requests[corev1.ResourceCPU] = *overridden
+}
+
+// If a container CPU limit has not been specified or defaulted, the CPU request is
+// overridden to this percentage of the original request (stored in a pod annotation).
+func (m *podMutator) OverrideCPUWithRequest(resources *corev1.ResourceRequirements, name string, pod *corev1.Pod) {
+	if m.config.CpuRequestToRequestRatio == 0 {
+		return
+	}
+
+	key := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, name)
+	strValue, found := pod.Annotations[key]
+	if !found {
+		klog.Warningf("failed to find %q annotation for pod %s/%s; skipping CPU request override", key, pod.Namespace, pod.Name)
+		return
+	}
+
+	request, err := resource.ParseQuantity(strValue)
+	if err != nil {
+		klog.Warningf("failed to parse %q annotation for pod %s/%s: %v; skipping CPU request override", key, pod.Namespace, pod.Name, err)
+		return
+	}
+
+	if request.IsZero() {
+		return
+	}
+
+	amount := float64(request.MilliValue()) * m.config.CpuRequestToRequestRatio
+	overridden := resource.NewMilliQuantity(int64(amount), request.Format)
+
+	if m.IsCpuFloorSpecified() && overridden.Cmp(*m.floor.CPU) < 0 {
+		klog.V(5).Infof("%s pod request %q below namespace minimum; setting request to %q", corev1.ResourceCPU, overridden.String(), m.floor.CPU.String())
+		clone := m.floor.CPU.DeepCopy()
+		overridden = &clone
+	}
+
+	if m.IsCpuCeilingSpecified() && overridden.Cmp(*m.ceiling.CPU) > 0 {
+		klog.V(5).Infof("%s pod request %q above namespace maximum; setting request to %q", corev1.ResourceCPU, overridden.String(), m.ceiling.CPU.String())
 		clone := m.ceiling.CPU.DeepCopy()
 		overridden = &clone
 	}

--- a/pkg/clusterresourceoverride/mutator_test.go
+++ b/pkg/clusterresourceoverride/mutator_test.go
@@ -1,6 +1,7 @@
 package clusterresourceoverride
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,76 +16,171 @@ const (
 )
 
 func TestMutator_Mutate(t *testing.T) {
+	
 	cpu := resource.MustParse("1m")
 	memory := resource.MustParse("1Mi")
-	floor := &CPUMemory{
-		CPU:    &cpu,
-		Memory: &memory,
-	}
-	config := &Config{
-		LimitCPUToMemoryRatio:     2.0,
-		CpuRequestToLimitRatio:    0.25,
-		MemoryRequestToLimitRatio: 0.5,
-	}
-	mutator, err := NewMutator(config, floor, &CPUMemory{}, factor)
-	require.NoError(t, err)
-	require.NotNil(t, mutator)
+	
+	// Tests the mutator using CPURequestToLimitRatio as the CPU request override
+	t.Run("WithCpuRequestToLimitRatio", func(t *testing.T) {
+		floor := &CPUMemory{
+			CPU:    &cpu,
+			Memory: &memory,
+		}
+		config := &Config{
+			LimitCPUToMemoryRatio:     2.0,
+			CpuRequestToLimitRatio:    0.25,
+			MemoryRequestToLimitRatio: 0.5,
+			CpuRequestToRequestRatio:  0,
+		}
+		mutator, err := NewMutator(config, floor, &CPUMemory{}, factor)
+		require.NoError(t, err)
+		require.NotNil(t, mutator)
 
-	pod := &corev1.Pod{
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name: "db",
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("16Gi"),
-							corev1.ResourceCPU:    resource.MustParse("8000m"),
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "db",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("16Gi"),
+								corev1.ResourceCPU:    resource.MustParse("8000m"),
+							},
+						},
+					},
+					{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("2Gi"),
+								corev1.ResourceCPU:    resource.MustParse("2000m"),
+							},
 						},
 					},
 				},
-				{
-					Name: "app",
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("2Gi"),
-							corev1.ResourceCPU:    resource.MustParse("2000m"),
+				InitContainers: []corev1.Container{
+					{
+						Name: "init",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+								corev1.ResourceCPU:    resource.MustParse("1000m"),
+							},
 						},
 					},
 				},
 			},
-			InitContainers: []corev1.Container{
-				{
-					Name: "init",
-					Resources: corev1.ResourceRequirements{
-						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("1Gi"),
-							corev1.ResourceCPU:    resource.MustParse("1000m"),
+		}
+
+		podGot, errGot := mutator.Mutate(pod)
+
+		assert.NoError(t, errGot)
+		assert.NotNil(t, podGot)
+
+		// verify init container
+		validate(t, podGot.Spec.InitContainers[0].Resources.Requests, corev1.ResourceMemory, resource.MustParse("512Mi"))
+		validate(t, podGot.Spec.InitContainers[0].Resources.Limits, corev1.ResourceCPU, resource.MustParse("2000m"))
+		validate(t, podGot.Spec.InitContainers[0].Resources.Requests, corev1.ResourceCPU, resource.MustParse("500m"))
+
+		// verify db container
+		validate(t, podGot.Spec.Containers[0].Resources.Requests, corev1.ResourceMemory, resource.MustParse("8Gi"))
+		validate(t, podGot.Spec.Containers[0].Resources.Limits, corev1.ResourceCPU, resource.MustParse("32000m"))
+		validate(t, podGot.Spec.Containers[0].Resources.Requests, corev1.ResourceCPU, resource.MustParse("8000m"))
+
+		// verify app container
+		validate(t, podGot.Spec.Containers[1].Resources.Requests, corev1.ResourceMemory, resource.MustParse("1Gi"))
+		validate(t, podGot.Spec.Containers[1].Resources.Limits, corev1.ResourceCPU, resource.MustParse("4000m"))
+		validate(t, podGot.Spec.Containers[1].Resources.Requests, corev1.ResourceCPU, resource.MustParse("1000m"))
+	})
+	
+	// Tests mutator using CPURequestToRequestRatio as the CPU resource override
+	// Ensures CPURequestToRequestRatio overwrites CPURequestToLimitRatio
+	// Ensures CPURequestToRequestRatio doesn't compute with request from CPURequestToLimitRatio
+	// Tests the per container annotations to ensure the mutator applies the override 
+	//   according to each container's original request
+	t.Run("WithCpuRequestToRequestRatio", func(t *testing.T) {
+		floor := &CPUMemory{
+			CPU:    &cpu,
+			Memory: &memory,
+		}
+		config := &Config{
+			LimitCPUToMemoryRatio:     2.0,
+			CpuRequestToLimitRatio:    0.25,
+			MemoryRequestToLimitRatio: 0.5,
+			CpuRequestToRequestRatio:  0.25,
+		}
+		mutator, err := NewMutator(config, floor, &CPUMemory{}, factor)
+		require.NoError(t, err)
+		require.NotNil(t, mutator)
+
+		pod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "db",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("16Gi"),
+								corev1.ResourceCPU:    resource.MustParse("8000m"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("4Gi"),
+								corev1.ResourceCPU:    resource.MustParse("2000m"),
+							},
+						},
+					},
+					{
+						Name: "app",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("2Gi"),
+								corev1.ResourceCPU:    resource.MustParse("2000m"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+								corev1.ResourceCPU:    resource.MustParse("1000m"),
+							},
+						},
+					},
+				},
+				InitContainers: []corev1.Container{
+					{
+						Name: "init",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+								corev1.ResourceCPU:    resource.MustParse("1000m"),
+							},
+							Requests: corev1.ResourceList{
+								corev1.ResourceMemory: resource.MustParse("512Mi"),
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+							},
 						},
 					},
 				},
 			},
-		},
-	}
+		}
 
-	podGot, errGot := mutator.Mutate(pod)
+		podGot, errGot := mutator.Mutate(pod)
 
-	assert.NoError(t, errGot)
-	assert.NotNil(t, podGot)
+		assert.NoError(t, errGot)
+		assert.NotNil(t, podGot)
 
-	// verify init container
-	validate(t, podGot.Spec.InitContainers[0].Resources.Requests, corev1.ResourceMemory, resource.MustParse("512Mi"))
-	validate(t, podGot.Spec.InitContainers[0].Resources.Limits, corev1.ResourceCPU, resource.MustParse("2000m"))
-	validate(t, podGot.Spec.InitContainers[0].Resources.Requests, corev1.ResourceCPU, resource.MustParse("500m"))
+		// verify init container
+		validate(t, podGot.Spec.InitContainers[0].Resources.Requests, corev1.ResourceMemory, resource.MustParse("512Mi"))
+		validate(t, podGot.Spec.InitContainers[0].Resources.Limits, corev1.ResourceCPU, resource.MustParse("2000m"))
+		validate(t, podGot.Spec.InitContainers[0].Resources.Requests, corev1.ResourceCPU, resource.MustParse("125m"))
 
-	// verify db container
-	validate(t, podGot.Spec.Containers[0].Resources.Requests, corev1.ResourceMemory, resource.MustParse("8Gi"))
-	validate(t, podGot.Spec.Containers[0].Resources.Limits, corev1.ResourceCPU, resource.MustParse("32000m"))
-	validate(t, podGot.Spec.Containers[0].Resources.Requests, corev1.ResourceCPU, resource.MustParse("8000m"))
+		// verify db container
+		validate(t, podGot.Spec.Containers[0].Resources.Requests, corev1.ResourceMemory, resource.MustParse("8Gi"))
+		validate(t, podGot.Spec.Containers[0].Resources.Limits, corev1.ResourceCPU, resource.MustParse("32000m"))
+		validate(t, podGot.Spec.Containers[0].Resources.Requests, corev1.ResourceCPU, resource.MustParse("500m"))
 
-	// verify app container
-	validate(t, podGot.Spec.Containers[1].Resources.Requests, corev1.ResourceMemory, resource.MustParse("1Gi"))
-	validate(t, podGot.Spec.Containers[1].Resources.Limits, corev1.ResourceCPU, resource.MustParse("4000m"))
-	validate(t, podGot.Spec.Containers[1].Resources.Requests, corev1.ResourceCPU, resource.MustParse("1000m"))
+		// verify app container
+		validate(t, podGot.Spec.Containers[1].Resources.Requests, corev1.ResourceMemory, resource.MustParse("1Gi"))
+		validate(t, podGot.Spec.Containers[1].Resources.Limits, corev1.ResourceCPU, resource.MustParse("4000m"))
+		validate(t, podGot.Spec.Containers[1].Resources.Requests, corev1.ResourceCPU, resource.MustParse("250m"))
+	})
 }
 
 func TestMutator_OverrideMemory(t *testing.T) {
@@ -218,7 +314,401 @@ func TestMutator_OverrideMemory(t *testing.T) {
 	}
 }
 
-func TestMutator_OverrideCpu(t *testing.T) {
+func TestMutator_OverrideCPUWithRequest(t *testing.T) {
+	testContainerName := "test"
+	testAnnotation := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, testContainerName)
+	tests := []struct {
+		name    string
+		pod *corev1.Pod
+		mutator func() *podMutator
+		input   *corev1.ResourceRequirements
+		assert  func(t *testing.T, resources *corev1.ResourceRequirements)
+	}{
+		{
+			// happy path
+			name: "WithCpuRequest",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name: "test",
+					Annotations: map[string]string{
+						testAnnotation: "2000m",
+					},
+				},
+			},
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.25,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceCPU, resource.MustParse("500m"))
+			},
+		},
+		{
+			// request annotation not present
+			name: "WithoutCpuRequest",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name: "test",
+				},
+			},
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.25,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				_, found := resources.Requests[corev1.ResourceCPU]
+				require.False(t, found, "expected no CPU request to be set")
+			},
+		},
+		{
+			// Ratio override value not set
+			name: "WithRatioValueZero",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name: "test",
+					Annotations: map[string]string{
+						testAnnotation: "2000m",
+					},
+				},
+			},
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				_, found := resources.Requests[corev1.ResourceCPU]
+				require.False(t, found, "expected no CPU request to be set")
+			},
+		},
+		{
+			// CPU request modified from previous override
+			// Regression test to ensure annotation is used to get request
+			name: "WithModifiedRequest",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name: "test",
+					Annotations: map[string]string{
+						testAnnotation: "2000m",
+					},
+				},
+			},
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.25,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1000m"),
+				},
+			},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceCPU, resource.MustParse("500m"))
+			},
+		},
+		{
+			// Override is below the set floor
+			name: "WithOverrideBelowFloor",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name: "test",
+					Annotations: map[string]string{
+						testAnnotation: "1000m",
+					},
+				},
+			},
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.25,
+					},
+					floor: &CPUMemory{
+						CPU: func() *resource.Quantity {
+							q := resource.MustParse("500m")
+							return &q
+						}(),
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceCPU, resource.MustParse("500m"))
+			},
+		},
+		{
+			// Override is above the set ceiling
+			name: "WithOverrideAboveCeiling",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name: "test",
+					Annotations: map[string]string{
+						testAnnotation: "2000m",
+					},
+				},
+			},
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.5,
+					},
+					ceiling: &CPUMemory{
+						CPU: func() *resource.Quantity {
+							q := resource.MustParse("500m")
+							return &q
+						}(),
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceCPU, resource.MustParse("500m"))
+			},
+		},
+		{
+			// Override inbetween the set ceiling and floor
+			name: "WithOverrideBetweenFloorCeiling",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name: "test",
+					Annotations: map[string]string{
+						testAnnotation: "1000m",
+					},
+				},
+			},
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.5,
+					},
+					ceiling: &CPUMemory{
+						CPU: func() *resource.Quantity {
+							q := resource.MustParse("1000m")
+							return &q
+						}(),
+					},
+					floor: &CPUMemory{
+						CPU: func() *resource.Quantity {
+							q := resource.MustParse("250m")
+							return &q
+						}(),
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceCPU, resource.MustParse("500m"))
+			},
+		},
+		{
+			// Annotation value is "0", should be a no-op
+			name: "WithZeroAnnotationValue",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test",
+					Annotations: map[string]string{
+						testAnnotation: "0",
+					},
+				},
+			},
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.25,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				_, found := resources.Requests[corev1.ResourceCPU]
+				require.False(t, found, "expected no CPU request to be set")
+			},
+		},
+		{
+			// Container has limits but no request at all, no annotation set.
+			// CpuRequestToRequestRatio is configured but should be a no-op.
+			name: "WithNoRequestAndNoAnnotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test",
+				},
+			},
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.25,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+					corev1.ResourceCPU:    resource.MustParse("2000m"),
+				},
+			},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				// verify limits are unchanged
+				validate(t, resources.Limits, corev1.ResourceMemory, resource.MustParse("2Gi"))
+				validate(t, resources.Limits, corev1.ResourceCPU, resource.MustParse("2000m"))
+				// verify no requests were created
+				_, found := resources.Requests[corev1.ResourceCPU]
+				require.False(t, found, "expected no CPU request to be set")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target := test.mutator()
+
+			target.OverrideCPUWithRequest(test.input, testContainerName, test.pod)
+
+			test.assert(t, test.input)
+		})
+	}
+}
+
+func TestMutator_AnnotateOriginalRequest(t *testing.T) {
+	containerName := "mycontainer"
+	annotationKey := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, containerName)
+
+	tests := []struct {
+		name    string
+		mutator func() *podMutator
+		input   *corev1.ResourceRequirements
+		pod     *corev1.Pod
+		assert  func(t *testing.T, pod *corev1.Pod)
+	}{
+		{
+			// Annotation is written with the correct per-container key
+			name: "PerContainerAnnotation",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.25,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("500m"),
+				},
+			},
+			pod: &corev1.Pod{},
+			assert: func(t *testing.T, pod *corev1.Pod) {
+				val, found := pod.Annotations[annotationKey]
+				require.True(t, found, "expected per-container annotation to be set")
+				require.Equal(t, "500m", val)
+			},
+		},
+		{
+			// Second container does not overwrite first container's annotation
+			name: "MultipleContainersGetSeparateAnnotations",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						CpuRequestToRequestRatio: 0.25,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("200m"),
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, "other"): "1000m",
+					},
+				},
+			},
+			assert: func(t *testing.T, pod *corev1.Pod) {
+				otherKey := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, "other")
+				otherVal, otherFound := pod.Annotations[otherKey]
+				require.True(t, otherFound, "expected other container annotation to remain")
+				require.Equal(t, "1000m", otherVal)
+
+				val, found := pod.Annotations[annotationKey]
+				require.True(t, found, "expected this container annotation to be set")
+				require.Equal(t, "200m", val)
+			},
+		},
+		{
+			// No CPU request means no annotation is written
+			name: "ZeroRequestSkipsAnnotation",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{},
+				}
+			},
+			input: &corev1.ResourceRequirements{},
+			pod:   &corev1.Pod{},
+			assert: func(t *testing.T, pod *corev1.Pod) {
+				_, found := pod.Annotations[annotationKey]
+				require.False(t, found, "expected no annotation for zero request")
+			},
+		},
+		{
+			// Existing annotation is not overwritten on reinvocation
+			name: "ExistingAnnotationNotOverwritten",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{},
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1000m"),
+				},
+			},
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotationKey: "500m",
+					},
+				},
+			},
+			assert: func(t *testing.T, pod *corev1.Pod) {
+				val, found := pod.Annotations[annotationKey]
+				require.True(t, found)
+				require.Equal(t, "500m", val, "expected original annotation to be preserved")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			target := test.mutator()
+			target.AnnotateOriginalRequest(test.input, containerName, test.pod)
+			test.assert(t, test.pod)
+		})
+	}
+}
+
+func TestMutator_OverrideCpuWithLimit(t *testing.T) {
 	tests := []struct {
 		name    string
 		mutator func() *podMutator
@@ -323,7 +813,7 @@ func TestMutator_OverrideCpu(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			target := test.mutator()
 
-			target.OverrideCPU(test.input)
+			target.OverrideCPUWithLimit(test.input)
 
 			test.assert(t, test.input)
 		})

--- a/pkg/clusterresourceoverride/testdata/external.yaml
+++ b/pkg/clusterresourceoverride/testdata/external.yaml
@@ -4,3 +4,4 @@ spec:
   memoryRequestToLimitPercent: 25
   cpuRequestToLimitPercent: 50
   limitCPUToMemoryPercent: 200
+  cpuRequestToRequestPercent: 25


### PR DESCRIPTION
Add new override field to allow overriding CPU request by a percentage of the original CPU request value.

Jira: https://redhat.atlassian.net/browse/AUTOSCALE-705
Operator PR: https://github.com/openshift/cluster-resource-override-admission-operator/pull/211

**New Feature:**
- Added cpuRequestToRequestPercent override that sets a container's CPU request to a percentage of its original CPU request, for use when no CPU limit is set or when user wants to lower requests of workloads
- Store original CPU request in a per-container annotation to preserve the value across webhook reinvocations and prior overrides
- Unit tests to test the new field and prevent regression

**Extra Changes:**
- Fixed bug in DecodeWithFile where err was checked instead of openErr after os.Open
- Fixed log messages in OverrideCPUWithLimit that said "pod limit" instead of "pod request" and changed function name from OverrideCPU to OverrideCPUWithLimit for clarity
- Added reader.Close() to DecodeWithFile() in config.go as per code rabbit comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new configuration option to control CPU request overrides using a request-to-request percentage ratio.

* **Documentation**
  * Updated the configuration YAML examples to include the new CPU request-to-request parameter.

* **Bug Fixes**
  * Improved error handling when loading external configuration files to ensure the correct early-fail behavior.

* **Tests**
  * Expanded unit tests to validate the new CPU ratio conversion and request override behavior across key scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->