### PR TITLE
Fix overflow and percentage truncation in memory request override

### DIFF
--- a/pkg/clusterresourceoverride/mutator.go
+++ b/pkg/clusterresourceoverride/mutator.go
@@ -3,6 +3,8 @@ package clusterresourceoverride
 import (
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -151,15 +153,25 @@ func (m *podMutator) OverrideMemory(resources *corev1.ResourceRequirements) {
 	}
 
 	// memory is measured in whole bytes.
-	// the plugin rounds down to the nearest MiB rather than bytes to improve ease of use for end-users.
-	amount := limit.Value() * int64(m.config.MemoryRequestToLimitRatio*100) / 100
+	// the plugin rounds down to a whole MiB for BinarySI limits, or a whole MB for
+	// DecimalSI limits, rather than to the byte, to improve ease of use for end-users.
+	// limit.Value()*ratioPct overflows int64 for large limits (a 1Ei limit at 50%
+	// wraps to a smaller value; a 512Pi limit wraps negative) even when the final
+	// result fits, so do the multiply in big.Int. MemoryRequestToLimitRatio is a
+	// [0,1] fraction (the operator and CRD constrain the source percent to [1,100]);
+	// math.Round recovers the original integer percentage exactly, since e.g.
+	// 0.29*100 is 28.999999999999996 and a plain int64 cast truncates it to 28. With
+	// the ratio in [0,1] the result never exceeds the limit and fits int64.
+	ratioPct := int64(math.Round(m.config.MemoryRequestToLimitRatio * 100))
+	amountBig := new(big.Int).Mul(big.NewInt(limit.Value()), big.NewInt(ratioPct))
+	amount := amountBig.Quo(amountBig, big.NewInt(100)).Int64()
 	mod := modFunc(limit)
 
 	if rem := amount % mod; rem != 0 {
 		amount = amount - rem
 	}
 
-	overridden := resource.NewQuantity(int64(amount), limit.Format)
+	overridden := resource.NewQuantity(amount, limit.Format)
 	if m.IsMemoryFloorSpecified() && overridden.Cmp(*m.floor.Memory) < 0 {
 		klog.V(5).Infof("%s pod limit %q below namespace limit; setting limit to %q", corev1.ResourceMemory, overridden.String(), m.floor.Memory.String())
 		copy := m.floor.Memory.DeepCopy()

--- a/pkg/clusterresourceoverride/mutator_test.go
+++ b/pkg/clusterresourceoverride/mutator_test.go
@@ -2,6 +2,7 @@ package clusterresourceoverride
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,10 +17,10 @@ const (
 )
 
 func TestMutator_Mutate(t *testing.T) {
-	
+
 	cpu := resource.MustParse("1m")
 	memory := resource.MustParse("1Mi")
-	
+
 	// Tests the mutator using CPURequestToLimitRatio as the CPU request override
 	t.Run("WithCpuRequestToLimitRatio", func(t *testing.T) {
 		floor := &CPUMemory{
@@ -92,11 +93,11 @@ func TestMutator_Mutate(t *testing.T) {
 		validate(t, podGot.Spec.Containers[1].Resources.Limits, corev1.ResourceCPU, resource.MustParse("4000m"))
 		validate(t, podGot.Spec.Containers[1].Resources.Requests, corev1.ResourceCPU, resource.MustParse("1000m"))
 	})
-	
+
 	// Tests mutator using CPURequestToRequestRatio as the CPU resource override
 	// Ensures CPURequestToRequestRatio overwrites CPURequestToLimitRatio
 	// Ensures CPURequestToRequestRatio doesn't compute with request from CPURequestToLimitRatio
-	// Tests the per container annotations to ensure the mutator applies the override 
+	// Tests the per container annotations to ensure the mutator applies the override
 	//   according to each container's original request
 	t.Run("WithCpuRequestToRequestRatio", func(t *testing.T) {
 		floor := &CPUMemory{
@@ -301,6 +302,125 @@ func TestMutator_OverrideMemory(t *testing.T) {
 				validate(t, resources.Requests, corev1.ResourceMemory, resource.MustParse("2Gi"))
 			},
 		},
+		{
+			// Regression: limit.Value()*ratioPct overflowed int64 in the
+			// intermediate multiply. 1Ei is well within int64, so at 50% the
+			// request must be 512Pi; the overflowing product yielded ~20.48Pi.
+			name: "WithLargeLimitDoesNotOverflow",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						MemoryRequestToLimitRatio: 0.5,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Ei"),
+				},
+			},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceMemory, resource.MustParse("512Pi"))
+			},
+		},
+		{
+			// Regression: a 512Pi limit made the intermediate product wrap
+			// negative. At 50% the request must be 256Pi.
+			name: "WithVeryLargeLimitDoesNotWrapNegative",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: &Config{
+						MemoryRequestToLimitRatio: 0.5,
+					},
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("512Pi"),
+				},
+			},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceMemory, resource.MustParse("256Pi"))
+			},
+		},
+		{
+			// Regression: MemoryRequestToLimitPercent is stored as a float64 ratio,
+			// and 0.29*100 is 28.999999999999996, so a plain int64 cast truncated 29%
+			// to 28% and undercounted the request. Exercised through the real config
+			// conversion so the float round trip is covered.
+			name: "WithFractionalPercent29DoesNotUndercount",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: ConvertExternalConfig(&ClusterResourceOverride{
+						Spec: ClusterResourceOverrideSpec{MemoryRequestToLimitPercent: 29},
+					}),
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceMemory, resource.MustParse("296Mi"))
+			},
+		},
+		{
+			name: "WithFractionalPercent57DoesNotUndercount",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: ConvertExternalConfig(&ClusterResourceOverride{
+						Spec: ClusterResourceOverrideSpec{MemoryRequestToLimitPercent: 57},
+					}),
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceMemory, resource.MustParse("583Mi"))
+			},
+		},
+		{
+			name: "WithFractionalPercent58DoesNotUndercount",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: ConvertExternalConfig(&ClusterResourceOverride{
+						Spec: ClusterResourceOverrideSpec{MemoryRequestToLimitPercent: 58},
+					}),
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceMemory, resource.MustParse("593Mi"))
+			},
+		},
+		{
+			// DecimalSI limits round down to a whole MB (the modFunc default
+			// branch), not a MiB. 1E at 50% is exactly 500P, with no rounding loss.
+			name: "WithDecimalSILimitRoundsToMB",
+			mutator: func() *podMutator {
+				return &podMutator{
+					config: ConvertExternalConfig(&ClusterResourceOverride{
+						Spec: ClusterResourceOverrideSpec{MemoryRequestToLimitPercent: 50},
+					}),
+				}
+			},
+			input: &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1E"),
+				},
+			},
+			assert: func(t *testing.T, resources *corev1.ResourceRequirements) {
+				validate(t, resources.Requests, corev1.ResourceMemory, resource.MustParse("500P"))
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -314,12 +434,26 @@ func TestMutator_OverrideMemory(t *testing.T) {
 	}
 }
 
+// TestConvertExternalConfig_MemoryPercentRoundTrip locks the invariant behind the
+// 29/57/58 regressions: the external percent is stored as a float64 ratio, and
+// int64(math.Round(ratio*100)) must recover every whole percent exactly. A plain
+// int64 cast truncated 29 to 28, 57 to 56, and 58 to 57; math.Round recovers all 101.
+func TestConvertExternalConfig_MemoryPercentRoundTrip(t *testing.T) {
+	for pct := int64(0); pct <= 100; pct++ {
+		config := ConvertExternalConfig(&ClusterResourceOverride{
+			Spec: ClusterResourceOverrideSpec{MemoryRequestToLimitPercent: pct},
+		})
+		got := int64(math.Round(config.MemoryRequestToLimitRatio * 100))
+		require.Equalf(t, pct, got, "percent %d did not round-trip through the float64 ratio", pct)
+	}
+}
+
 func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 	testContainerName := "test"
 	testAnnotation := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, testContainerName)
 	tests := []struct {
 		name    string
-		pod *corev1.Pod
+		pod     *corev1.Pod
 		mutator func() *podMutator
 		input   *corev1.ResourceRequirements
 		assert  func(t *testing.T, resources *corev1.ResourceRequirements)
@@ -330,7 +464,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -354,7 +488,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 				},
 			},
 			mutator: func() *podMutator {
@@ -376,7 +510,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -402,7 +536,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -430,7 +564,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "1000m",
 					},
@@ -460,7 +594,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -490,7 +624,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "1000m",
 					},


### PR DESCRIPTION
#### What this PR does / why we need it

`OverrideMemory` computed the overridden memory request as `limit.Value() * int64(ratio*100) / 100`, which had two defects.

First, the multiplication ran before the division and overflowed `int64` even when the memory limit and the resulting request both fit. A container with `limits.memory: 1Ei` (2^60 bytes, well within int64) at a 0.5 ratio should receive a `512Pi` request, but the overflow yielded roughly `20.48Pi`; a `512Pi` limit produced a negative intermediate that the normal admission path then raised to the `1Mi` floor, so a container that should be accounted at `256Pi` was accounted at `1Mi`.

Second, `MemoryRequestToLimitPercent` is stored internally as a `float64` ratio, and reconstructing the percentage with `int64(ratio*100)` truncated it: `float64(29)/100*100` is `28.999999999999996`, so 29% became 28%, 57% became 56%, and 58% became 57%. These are ordinary, non-overflowing settings, and they under-counted the request.

The fix does the `limit * ratioPct / 100` multiply in `math/big.Int` so the intermediate cannot overflow, and recovers the percentage with `math.Round`, which returns every whole percent in `[0,100]` exactly. The source percent is constrained to `[1,100]` by the operator and CRD, so the result never exceeds the limit and fits int64.

Because the scheduler uses memory requests when placing a Pod, both defects under-account a container's memory.

Tests added to `TestMutator_OverrideMemory`: the `1Ei` and `512Pi` overflow cases, the 29/57/58% truncation cases (through the real config conversion), an exhaustive check that every `0..100%` round-trips through the float ratio, and a DecimalSI limit case.

The same float64 truncation exists in the CPU override paths; that is out of scope for this memory-focused change and is tracked separately in #112.

#### Does this PR introduce a user-facing change?

```release-note
Fixed memory request override calculations that could understate the request for very large memory limits (an int64 overflow) and for percentage settings affected by floating-point truncation, including 29%, 57%, and 58%.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory request/limit calculations for very large memory values by preventing arithmetic overflow.
  * Improved correctness when applying percentage-based memory ratios, including fractional percents.
  * Enhanced handling to ensure results align properly to memory unit boundaries.

* **Tests**
  * Added regression tests for large limits and fractional memory percentages, including decimal SI rounding.
  * Added a round-trip test to verify whole-number memory percent values are preserved during configuration conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

