### PR TITLE
Add namespace-scoped ResourceOverride support to admission webhook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/openshift/generic-admission-server v1.14.1-0.20260305203524-5df3cca1e3cd
 	github.com/stretchr/testify v1.11.1
 	gomodules.xyz/jsonpatch/v2 v2.5.0
+	gopkg.in/evanphx/json-patch.v4 v4.13.0
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
@@ -88,7 +89,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
-	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/clusterresourceoverride/admission.go
+++ b/pkg/clusterresourceoverride/admission.go
@@ -148,7 +148,6 @@ func NewAdmission(kubeClientConfig *restclient.Config, stopCh <-chan struct{}, c
 		limitQuerier: &namespaceLimitQuerier{
 			limitRangesLister: limitRanges.Lister(),
 		},
-		roLister: roLister,
 		resolver: NewOverrideResolver(roLister, config, eventRecorder),
 	}
 
@@ -183,7 +182,6 @@ type clusterResourceOverrideAdmission struct {
 	config       *Config
 	nsLister     corev1listers.NamespaceLister
 	limitQuerier *namespaceLimitQuerier
-	roLister     ResourceOverrideLister
 	resolver     *OverrideResolver
 }
 

--- a/pkg/clusterresourceoverride/admission.go
+++ b/pkg/clusterresourceoverride/admission.go
@@ -14,8 +14,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 
 	"github.com/openshift/cluster-resource-override-admission/pkg/api"
@@ -128,12 +131,25 @@ func NewAdmission(kubeClientConfig *restclient.Config, stopCh <-chan struct{}, c
 		return
 	}
 
+	roLister := NewResourceOverrideListerOrNil(kubeClientConfig, stopCh)
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{
+		Interface: client.CoreV1().Events(""),
+	})
+	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{
+		Component: "clusterresourceoverride-admission",
+	})
+
 	admission = &clusterResourceOverrideAdmission{
 		config:   config,
 		nsLister: namespaces.Lister(),
 		limitQuerier: &namespaceLimitQuerier{
 			limitRangesLister: limitRanges.Lister(),
 		},
+		roLister: roLister,
+		resolver: NewOverrideResolver(roLister, config, eventRecorder),
 	}
 
 	return
@@ -167,6 +183,8 @@ type clusterResourceOverrideAdmission struct {
 	config       *Config
 	nsLister     corev1listers.NamespaceLister
 	limitQuerier *namespaceLimitQuerier
+	roLister     ResourceOverrideLister
+	resolver     *OverrideResolver
 }
 
 func (p *clusterResourceOverrideAdmission) GetConfiguration() *Config {
@@ -236,7 +254,12 @@ func (p *clusterResourceOverrideAdmission) Admit(request *admissionv1.AdmissionR
 
 	klog.V(5).Infof("namespace=%s initial pod: initContainers=%#v containers=%#v", request.Namespace, pod.Spec.InitContainers, pod.Spec.Containers)
 
-	mutator, err := NewMutator(p.config, setNamespaceFloor(nsMinimum), nsMaximum, cpuBaseScaleFactor)
+	effectiveConfig := p.config
+	if p.resolver != nil {
+		effectiveConfig = p.resolver.ResolveConfig(request.Namespace, pod)
+	}
+
+	mutator, err := NewMutator(effectiveConfig, setNamespaceFloor(nsMinimum), nsMaximum, cpuBaseScaleFactor)
 	if err != nil {
 		return admissionresponse.WithInternalServerError(request, err)
 	}

--- a/pkg/clusterresourceoverride/admission_test.go
+++ b/pkg/clusterresourceoverride/admission_test.go
@@ -119,7 +119,7 @@ func TestIsApplicable_NonPodResourceNotApplicable(t *testing.T) {
 func newFakeNamespaceLister(namespaces ...*corev1.Namespace) corev1listers.NamespaceLister {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
 	for _, ns := range namespaces {
-		indexer.Add(ns)
+		_ = indexer.Add(ns)
 	}
 	return corev1listers.NewNamespaceLister(indexer)
 }
@@ -547,7 +547,7 @@ func newFakeLimitRangeListerWithRange(namespace string, min, max resource.Quanti
 			},
 		},
 	}
-	indexer.Add(lr)
+	_ = indexer.Add(lr)
 	return corev1listers.NewLimitRangeLister(indexer)
 }
 

--- a/pkg/clusterresourceoverride/admission_test.go
+++ b/pkg/clusterresourceoverride/admission_test.go
@@ -265,7 +265,6 @@ func TestAdmit_ROMatchOverridesClusterConfig(t *testing.T) {
 		limitQuerier: &namespaceLimitQuerier{
 			limitRangesLister: newFakeLimitRangeLister(),
 		},
-		roLister: roLister,
 		resolver: NewOverrideResolver(roLister, croConfig, nil),
 	}
 
@@ -333,7 +332,6 @@ func TestAdmit_NoROMatch_FallsBackToClusterConfig(t *testing.T) {
 		limitQuerier: &namespaceLimitQuerier{
 			limitRangesLister: newFakeLimitRangeLister(),
 		},
-		roLister: roLister,
 		resolver: NewOverrideResolver(roLister, croConfig, nil),
 	}
 
@@ -438,7 +436,6 @@ func TestAdmit_MultipleROMatches_LexicographicWinner(t *testing.T) {
 		limitQuerier: &namespaceLimitQuerier{
 			limitRangesLister: newFakeLimitRangeLister(),
 		},
-		roLister: roLister,
 		resolver: NewOverrideResolver(roLister, croConfig, nil),
 	}
 
@@ -492,7 +489,6 @@ func TestAdmit_EmptySelector_MatchesAllPods(t *testing.T) {
 		limitQuerier: &namespaceLimitQuerier{
 			limitRangesLister: newFakeLimitRangeLister(),
 		},
-		roLister: roLister,
 		resolver: NewOverrideResolver(roLister, croConfig, nil),
 	}
 
@@ -577,7 +573,6 @@ func TestAdmit_ROWithLimitRangeFloor(t *testing.T) {
 				corev1.ResourceCPU,
 			),
 		},
-		roLister: roLister,
 		resolver: NewOverrideResolver(roLister, croConfig, nil),
 	}
 
@@ -637,7 +632,6 @@ func TestAdmit_ROWithLimitRangeCeiling(t *testing.T) {
 				corev1.ResourceCPU,
 			),
 		},
-		roLister: roLister,
 		resolver: NewOverrideResolver(roLister, croConfig, nil),
 	}
 
@@ -692,7 +686,6 @@ func TestAdmit_ROWithCPURequestToRequestPercent(t *testing.T) {
 		limitQuerier: &namespaceLimitQuerier{
 			limitRangesLister: newFakeLimitRangeLister(),
 		},
-		roLister: roLister,
 		resolver: NewOverrideResolver(roLister, croConfig, nil),
 	}
 
@@ -955,7 +948,6 @@ func TestAdmit_ROWithLimitCPUToMemory(t *testing.T) {
 		limitQuerier: &namespaceLimitQuerier{
 			limitRangesLister: newFakeLimitRangeLister(),
 		},
-		roLister: roLister,
 		resolver: NewOverrideResolver(roLister, croConfig, nil),
 	}
 

--- a/pkg/clusterresourceoverride/admission_test.go
+++ b/pkg/clusterresourceoverride/admission_test.go
@@ -1,15 +1,20 @@
 package clusterresourceoverride
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestSetNamespaceFloor(t *testing.T) {
@@ -43,4 +48,952 @@ func TestAdmissionUpdateRequestsNotApplicable(t *testing.T) {
 	}
 	applicable := admission.IsApplicable(req)
 	assert.False(t, applicable)
+}
+
+func TestSetNamespaceFloor_NilInput(t *testing.T) {
+	floorGot := setNamespaceFloor(nil)
+	require.NotNil(t, floorGot)
+	assert.True(t, defaultCPUFloor.Equal(*floorGot.CPU), "nil input should use default CPU floor")
+	assert.True(t, defaultMemoryFloor.Equal(*floorGot.Memory), "nil input should use default memory floor")
+}
+
+func TestSetNamespaceFloor_PartialNilCPU(t *testing.T) {
+	memory := resource.MustParse("2Gi")
+	floorGot := setNamespaceFloor(&CPUMemory{CPU: nil, Memory: &memory})
+	require.NotNil(t, floorGot)
+	assert.True(t, defaultCPUFloor.Equal(*floorGot.CPU), "nil CPU should use default")
+	assert.True(t, memory.Equal(*floorGot.Memory), "non-nil memory should override default")
+}
+
+func TestSetNamespaceFloor_PartialNilMemory(t *testing.T) {
+	cpu := resource.MustParse("500m")
+	floorGot := setNamespaceFloor(&CPUMemory{CPU: &cpu, Memory: nil})
+	require.NotNil(t, floorGot)
+	assert.True(t, cpu.Equal(*floorGot.CPU), "non-nil CPU should override default")
+	assert.True(t, defaultMemoryFloor.Equal(*floorGot.Memory), "nil memory should use default")
+}
+
+func TestGetConfiguration(t *testing.T) {
+	config := &Config{CpuRequestToLimitRatio: 0.5}
+	a := &clusterResourceOverrideAdmission{config: config}
+	assert.Equal(t, config, a.GetConfiguration())
+}
+
+func TestIsApplicable_CreatePod(t *testing.T) {
+	a := clusterResourceOverrideAdmission{}
+	req := &admissionv1.AdmissionRequest{
+		Operation: admissionv1.Create,
+		Resource:  metav1.GroupVersionResource{Resource: string(corev1.ResourcePods)},
+	}
+	assert.True(t, a.IsApplicable(req))
+}
+
+func TestIsApplicable_DeleteNotApplicable(t *testing.T) {
+	a := clusterResourceOverrideAdmission{}
+	req := &admissionv1.AdmissionRequest{
+		Operation: admissionv1.Delete,
+		Resource:  metav1.GroupVersionResource{Resource: string(corev1.ResourcePods)},
+	}
+	assert.False(t, a.IsApplicable(req))
+}
+
+func TestIsApplicable_SubResourceNotApplicable(t *testing.T) {
+	a := clusterResourceOverrideAdmission{}
+	req := &admissionv1.AdmissionRequest{
+		Operation:   admissionv1.Create,
+		Resource:    metav1.GroupVersionResource{Resource: string(corev1.ResourcePods)},
+		SubResource: "status",
+	}
+	assert.False(t, a.IsApplicable(req))
+}
+
+func TestIsApplicable_NonPodResourceNotApplicable(t *testing.T) {
+	a := clusterResourceOverrideAdmission{}
+	req := &admissionv1.AdmissionRequest{
+		Operation: admissionv1.Create,
+		Resource:  metav1.GroupVersionResource{Resource: "deployments"},
+	}
+	assert.False(t, a.IsApplicable(req))
+}
+
+func newFakeNamespaceLister(namespaces ...*corev1.Namespace) corev1listers.NamespaceLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, ns := range namespaces {
+		indexer.Add(ns)
+	}
+	return corev1listers.NewNamespaceLister(indexer)
+}
+
+func TestIsExempt_OptedInNamespace(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "my-app",
+			Labels: map[string]string{EnabledLabelName: "true"},
+		},
+	}
+	a := &clusterResourceOverrideAdmission{nsLister: newFakeNamespaceLister(ns)}
+
+	req := &admissionv1.AdmissionRequest{Namespace: "my-app"}
+	exempt, selinuxExempt, resp := a.IsExempt(req)
+
+	assert.False(t, exempt, "opted-in namespace should not be exempt")
+	assert.True(t, selinuxExempt, "selinux should still be exempt without its label")
+	assert.Nil(t, resp)
+}
+
+func TestIsExempt_NoLabel(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-app",
+		},
+	}
+	a := &clusterResourceOverrideAdmission{nsLister: newFakeNamespaceLister(ns)}
+
+	req := &admissionv1.AdmissionRequest{Namespace: "my-app"}
+	exempt, selinuxExempt, resp := a.IsExempt(req)
+
+	assert.True(t, exempt, "namespace without label should be exempt")
+	assert.True(t, selinuxExempt)
+	assert.Nil(t, resp)
+}
+
+func TestIsExempt_LabelSetToFalse(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "my-app",
+			Labels: map[string]string{EnabledLabelName: "false"},
+		},
+	}
+	a := &clusterResourceOverrideAdmission{nsLister: newFakeNamespaceLister(ns)}
+
+	req := &admissionv1.AdmissionRequest{Namespace: "my-app"}
+	exempt, _, resp := a.IsExempt(req)
+
+	assert.True(t, exempt, "label=false should be exempt")
+	assert.Nil(t, resp)
+}
+
+func TestIsExempt_NamespaceNotFound(t *testing.T) {
+	a := &clusterResourceOverrideAdmission{nsLister: newFakeNamespaceLister()}
+
+	req := &admissionv1.AdmissionRequest{Namespace: "does-not-exist"}
+	exempt, selinuxExempt, resp := a.IsExempt(req)
+
+	assert.True(t, exempt)
+	assert.True(t, selinuxExempt)
+	assert.NotNil(t, resp, "namespace not found should set forbidden response")
+}
+
+func TestIsExempt_SelinuxLabelEnabled(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-app",
+			Labels: map[string]string{
+				EnabledLabelName:           "true",
+				SelinuxFixEnabledLabelName: "true",
+			},
+		},
+	}
+	a := &clusterResourceOverrideAdmission{nsLister: newFakeNamespaceLister(ns)}
+
+	req := &admissionv1.AdmissionRequest{Namespace: "my-app"}
+	exempt, selinuxExempt, resp := a.IsExempt(req)
+
+	assert.False(t, exempt)
+	assert.False(t, selinuxExempt)
+	assert.Nil(t, resp)
+}
+
+func TestIsExempt_OnlySelinuxLabel(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-app",
+			Labels: map[string]string{
+				SelinuxFixEnabledLabelName: "true",
+			},
+		},
+	}
+	a := &clusterResourceOverrideAdmission{nsLister: newFakeNamespaceLister(ns)}
+
+	req := &admissionv1.AdmissionRequest{Namespace: "my-app"}
+	exempt, selinuxExempt, resp := a.IsExempt(req)
+
+	assert.True(t, exempt, "CRO exempt without CRO label")
+	assert.False(t, selinuxExempt, "selinux not exempt with selinux label")
+	assert.Nil(t, resp)
+}
+
+func newFakeLimitRangeLister() corev1listers.LimitRangeLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	return corev1listers.NewLimitRangeLister(indexer)
+}
+
+func makeAdmissionRequest(namespace string, pod *corev1.Pod) *admissionv1.AdmissionRequest {
+	podBytes, _ := json.Marshal(pod)
+	return &admissionv1.AdmissionRequest{
+		Namespace: namespace,
+		Resource:  metav1.GroupVersionResource{Resource: string(corev1.ResourcePods)},
+		Operation: admissionv1.Create,
+		Object:    runtime.RawExtension{Raw: podBytes},
+	}
+}
+
+func TestAdmit_ROMatchOverridesClusterConfig(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio:    0.25,
+		MemoryRequestToLimitRatio: 0.50,
+	}
+
+	roLister := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-a",
+				Selector:  &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent:    80,
+					MemoryRequestToLimitPercent: 90,
+				},
+			},
+		},
+	}}
+
+	a := &clusterResourceOverrideAdmission{
+		config: croConfig,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+		roLister: roLister,
+		resolver: NewOverrideResolver(roLister, croConfig, nil),
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-pod",
+			Labels: map[string]string{"app": "web"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1000m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed, "admission should be allowed")
+	require.NotNil(t, resp.Patch, "should produce a patch")
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "800m", cpuReq.String(), "CPU request should be 80%% of 1000m limit (RO config, not CRO 25%%)")
+
+	memReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceMemory]
+	oneGi := int64(1024 * 1024 * 1024)
+	expectedMem := oneGi * 90 / 100
+	expectedMem = expectedMem - (expectedMem % (1024 * 1024))
+	assert.Equal(t, resource.NewQuantity(expectedMem, resource.BinarySI).String(), memReq.String(),
+		"Memory request should be 90%% of 1Gi (RO config, not CRO 50%%)")
+}
+
+func TestAdmit_NoROMatch_FallsBackToClusterConfig(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio:    0.25,
+		MemoryRequestToLimitRatio: 0.50,
+	}
+
+	roLister := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-a",
+				Selector:  &metav1.LabelSelector{MatchLabels: map[string]string{"app": "backend"}},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 80,
+				},
+			},
+		},
+	}}
+
+	a := &clusterResourceOverrideAdmission{
+		config: croConfig,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+		roLister: roLister,
+		resolver: NewOverrideResolver(roLister, croConfig, nil),
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-pod",
+			Labels: map[string]string{"app": "web"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "250m", cpuReq.String(), "CPU request should be 25%% of limit (CRO fallback)")
+}
+
+func TestAdmit_NilResolver_UsesClusterConfig(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.25,
+	}
+
+	a := &clusterResourceOverrideAdmission{
+		config:   croConfig,
+		resolver: nil,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "250m", cpuReq.String(), "nil resolver should use CRO config")
+}
+
+func TestAdmit_MultipleROMatches_LexicographicWinner(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.25,
+	}
+
+	roLister := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-beta",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 90},
+			},
+			{
+				Namespace: "test-ns",
+				Name:      "override-alpha",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 50},
+			},
+		},
+	}}
+
+	a := &clusterResourceOverrideAdmission{
+		config: croConfig,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+		roLister: roLister,
+		resolver: NewOverrideResolver(roLister, croConfig, nil),
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "500m", cpuReq.String(), "override-alpha (50%%) should win over override-beta (90%%)")
+}
+
+func TestAdmit_EmptySelector_MatchesAllPods(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.25,
+	}
+
+	roLister := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "wildcard",
+				Selector:  &metav1.LabelSelector{},
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 60},
+			},
+		},
+	}}
+
+	a := &clusterResourceOverrideAdmission{
+		config: croConfig,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+		roLister: roLister,
+		resolver: NewOverrideResolver(roLister, croConfig, nil),
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-pod",
+			Labels: map[string]string{"tier": "anything"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "600m", cpuReq.String(), "empty selector should match, using RO 60%%")
+}
+
+func newFakeLimitRangeListerWithRange(namespace string, min, max resource.Quantity, resourceName corev1.ResourceName) corev1listers.LimitRangeLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	lr := &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "limits",
+			Namespace: namespace,
+		},
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{
+				{
+					Type: corev1.LimitTypeContainer,
+					Min:  corev1.ResourceList{resourceName: min},
+					Max:  corev1.ResourceList{resourceName: max},
+				},
+			},
+		},
+	}
+	indexer.Add(lr)
+	return corev1listers.NewLimitRangeLister(indexer)
+}
+
+func TestAdmit_ROWithLimitRangeFloor(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.25,
+	}
+
+	roLister := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "low-ratio",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 5},
+			},
+		},
+	}}
+
+	a := &clusterResourceOverrideAdmission{
+		config: croConfig,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeListerWithRange(
+				"test-ns",
+				resource.MustParse("200m"),
+				resource.MustParse("4000m"),
+				corev1.ResourceCPU,
+			),
+		},
+		roLister: roLister,
+		resolver: NewOverrideResolver(roLister, croConfig, nil),
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "200m", cpuReq.String(),
+		"RO config 5%% of 1000m = 50m, but LimitRange floor is 200m, so floor should win")
+}
+
+func TestAdmit_ROWithLimitRangeCeiling(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.25,
+	}
+
+	roLister := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "high-ratio",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 100},
+			},
+		},
+	}}
+
+	a := &clusterResourceOverrideAdmission{
+		config: croConfig,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeListerWithRange(
+				"test-ns",
+				resource.MustParse("10m"),
+				resource.MustParse("500m"),
+				corev1.ResourceCPU,
+			),
+		},
+		roLister: roLister,
+		resolver: NewOverrideResolver(roLister, croConfig, nil),
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "500m", cpuReq.String(),
+		"RO config 100%% of 1000m = 1000m, but LimitRange ceiling is 500m, so ceiling should win")
+}
+
+func TestAdmit_ROWithCPURequestToRequestPercent(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.25,
+	}
+
+	roLister := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "req-to-req",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToRequestPercent: 50},
+			},
+		},
+	}}
+
+	a := &clusterResourceOverrideAdmission{
+		config: croConfig,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+		roLister: roLister,
+		resolver: NewOverrideResolver(roLister, croConfig, nil),
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "500m", cpuReq.String(),
+		"CPURequestToRequestPercent=50 should halve the original 1000m request")
+}
+
+func TestAdmit_MalformedPodJSON(t *testing.T) {
+	a := &clusterResourceOverrideAdmission{
+		config: &Config{CpuRequestToLimitRatio: 0.25},
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+	}
+
+	req := &admissionv1.AdmissionRequest{
+		Namespace: "test-ns",
+		Resource:  metav1.GroupVersionResource{Resource: string(corev1.ResourcePods)},
+		Operation: admissionv1.Create,
+		Object:    runtime.RawExtension{Raw: []byte(`{invalid json}`)},
+	}
+	resp := a.Admit(req)
+
+	assert.NotNil(t, resp)
+	assert.NotNil(t, resp.Result)
+	assert.Equal(t, int32(400), resp.Result.Code, "malformed JSON should return 400 Bad Request")
+}
+
+func TestAdmit_InitContainers(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.5,
+	}
+
+	a := &clusterResourceOverrideAdmission{
+		config:   croConfig,
+		resolver: nil,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{
+					Name: "init",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2000m"),
+						},
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	initCpuReq := patched.Spec.InitContainers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "1", initCpuReq.String(), "init container CPU request should be 50%% of 2000m")
+
+	mainCpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "500m", mainCpuReq.String(), "main container CPU request should be 50%% of 1000m")
+}
+
+func TestAdmit_MultipleContainers(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.25,
+	}
+
+	a := &clusterResourceOverrideAdmission{
+		config:   croConfig,
+		resolver: nil,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+					},
+				},
+				{
+					Name: "sidecar",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("500m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	appCpu := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "250m", appCpu.String(), "app container: 25%% of 1000m")
+
+	sidecarCpu := patched.Spec.Containers[1].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "125m", sidecarCpu.String(), "sidecar container: 25%% of 500m")
+}
+
+func TestAdmit_PodWithExistingRequests(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.5,
+	}
+
+	a := &clusterResourceOverrideAdmission{
+		config:   croConfig,
+		resolver: nil,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1000m"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("200m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuReq := patched.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	assert.Equal(t, "500m", cpuReq.String(),
+		"existing request should be overridden to 50%% of limit, not preserved")
+}
+
+func TestAdmit_PodWithNoLimits_NoMutation(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio:    0.5,
+		MemoryRequestToLimitRatio: 0.5,
+	}
+
+	a := &clusterResourceOverrideAdmission{
+		config:   croConfig,
+		resolver: nil,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:      "main",
+					Resources: corev1.ResourceRequirements{},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+}
+
+func TestAdmit_ROWithLimitCPUToMemory(t *testing.T) {
+	croConfig := &Config{
+		CpuRequestToLimitRatio: 0.25,
+	}
+
+	roLister := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "mem-to-cpu",
+				Selector:  nil,
+				Spec: ClusterResourceOverrideSpec{
+					LimitCPUToMemoryPercent: 100,
+				},
+			},
+		},
+	}}
+
+	a := &clusterResourceOverrideAdmission{
+		config: croConfig,
+		limitQuerier: &namespaceLimitQuerier{
+			limitRangesLister: newFakeLimitRangeLister(),
+		},
+		roLister: roLister,
+		resolver: NewOverrideResolver(roLister, croConfig, nil),
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	req := makeAdmissionRequest("test-ns", pod)
+	resp := a.Admit(req)
+
+	require.True(t, resp.Allowed)
+	require.NotNil(t, resp.Patch)
+
+	var patched corev1.Pod
+	podBytes, _ := json.Marshal(pod)
+	applyJSONPatch(t, podBytes, resp.Patch, &patched)
+
+	cpuLimit := patched.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
+	assert.Equal(t, "1", cpuLimit.String(),
+		"LimitCPUToMemory at 100%% with 1Gi should set CPU limit to 1 core")
+}
+
+func applyJSONPatch(t *testing.T, original, patchBytes []byte, target interface{}) {
+	t.Helper()
+	patch, err := jsonpatch.DecodePatch(patchBytes)
+	require.NoError(t, err)
+	result, err := patch.Apply(original)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(result, target))
 }

--- a/pkg/clusterresourceoverride/config_test.go
+++ b/pkg/clusterresourceoverride/config_test.go
@@ -24,6 +24,78 @@ func TestConvertExternalConfig(t *testing.T) {
 	assert.Equal(t, 0.25, configGot.CpuRequestToRequestRatio)
 }
 
+func TestConvertExternalConfig_ZeroValues(t *testing.T) {
+	external := &ClusterResourceOverride{
+		Spec: ClusterResourceOverrideSpec{},
+	}
+
+	configGot := ConvertExternalConfig(external)
+	assert.NotNil(t, configGot)
+	assert.Equal(t, 0.0, configGot.LimitCPUToMemoryRatio)
+	assert.Equal(t, 0.0, configGot.CpuRequestToLimitRatio)
+	assert.Equal(t, 0.0, configGot.MemoryRequestToLimitRatio)
+	assert.Equal(t, 0.0, configGot.CpuRequestToRequestRatio)
+	assert.False(t, configGot.ForceSelinuxRelabel)
+}
+
+func TestConvertExternalConfig_ForceSelinuxRelabel(t *testing.T) {
+	external := &ClusterResourceOverride{
+		Spec: ClusterResourceOverrideSpec{
+			ForceSelinuxRelabel: true,
+		},
+	}
+
+	configGot := ConvertExternalConfig(external)
+	assert.True(t, configGot.ForceSelinuxRelabel)
+}
+
+func TestConvertExternalConfig_NegativeValues(t *testing.T) {
+	external := &ClusterResourceOverride{
+		Spec: ClusterResourceOverrideSpec{
+			CPURequestToLimitPercent:    -50,
+			MemoryRequestToLimitPercent: -25,
+		},
+	}
+
+	configGot := ConvertExternalConfig(external)
+	assert.Equal(t, -0.5, configGot.CpuRequestToLimitRatio)
+	assert.Equal(t, -0.25, configGot.MemoryRequestToLimitRatio)
+}
+
+func TestConvertExternalConfig_LargeValues(t *testing.T) {
+	external := &ClusterResourceOverride{
+		Spec: ClusterResourceOverrideSpec{
+			LimitCPUToMemoryPercent: 100000,
+		},
+	}
+
+	configGot := ConvertExternalConfig(external)
+	assert.Equal(t, 1000.0, configGot.LimitCPUToMemoryRatio)
+}
+
+func TestConfigString(t *testing.T) {
+	config := &Config{
+		LimitCPUToMemoryRatio:     0.5,
+		CpuRequestToLimitRatio:    0.25,
+		MemoryRequestToLimitRatio: 0.5,
+		CpuRequestToRequestRatio:  0.3,
+		ForceSelinuxRelabel:       true,
+	}
+
+	s := config.String()
+	assert.Contains(t, s, "LimitCPUToMemoryRatio=0.5")
+	assert.Contains(t, s, "CpuRequestToLimitRatio=0.25")
+	assert.Contains(t, s, "MemoryRequestToLimitRatio=0.5")
+	assert.Contains(t, s, "CpuRequestToRequestRatio=0.3")
+	assert.Contains(t, s, "ForceSelinuxRelabel=true")
+}
+
+func TestDecodeWithFile_NonExistentFile(t *testing.T) {
+	_, err := DecodeWithFile("testdata/does-not-exist.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to load file")
+}
+
 func TestDecodeWithFile(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/clusterresourceoverride/exempt_test.go
+++ b/pkg/clusterresourceoverride/exempt_test.go
@@ -39,6 +39,54 @@ func TestIsNamespaceExempt(t *testing.T) {
 			name: "kube-dns",
 			want: true,
 		},
+		{
+			name: "",
+			want: false,
+		},
+		{
+			name: "default",
+			want: false,
+		},
+		{
+			name: "my-app",
+			want: false,
+		},
+		{
+			name: "Openshift",
+			want: false,
+		},
+		{
+			name: "KUBE",
+			want: false,
+		},
+		{
+			name: "Kubernetes",
+			want: false,
+		},
+		{
+			name: "openshiftfoo",
+			want: false,
+		},
+		{
+			name: "kubefoo",
+			want: false,
+		},
+		{
+			name: "my-kube-system",
+			want: false,
+		},
+		{
+			name: "not-openshift-but-contains-it",
+			want: false,
+		},
+		{
+			name: "openshift-",
+			want: true,
+		},
+		{
+			name: "kube-",
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/clusterresourceoverride/resolver.go
+++ b/pkg/clusterresourceoverride/resolver.go
@@ -18,12 +18,14 @@ var resourceOverrideGVK = schema.GroupVersionKind{
 	Kind:    "ResourceOverride",
 }
 
+// OverrideResolver resolves the effective override config for a pod by matching ResourceOverride objects.
 type OverrideResolver struct {
 	lister        ResourceOverrideLister
 	clusterConfig *Config
 	recorder      record.EventRecorder
 }
 
+// NewOverrideResolver creates a resolver that selects a ResourceOverride or falls back to the cluster config.
 func NewOverrideResolver(lister ResourceOverrideLister, clusterConfig *Config, recorder record.EventRecorder) *OverrideResolver {
 	return &OverrideResolver{
 		lister:        lister,
@@ -32,6 +34,7 @@ func NewOverrideResolver(lister ResourceOverrideLister, clusterConfig *Config, r
 	}
 }
 
+// ResolveConfig returns the override config for the given pod, falling back to the cluster config when no ResourceOverride matches.
 func (r *OverrideResolver) ResolveConfig(namespace string, pod *corev1.Pod) *Config {
 	if r.lister == nil {
 		klog.V(5).Infof("namespace=%s ResourceOverride lister is nil, using ClusterResourceOverride config", namespace)

--- a/pkg/clusterresourceoverride/resolver.go
+++ b/pkg/clusterresourceoverride/resolver.go
@@ -1,0 +1,133 @@
+package clusterresourceoverride
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+)
+
+var resourceOverrideGVK = schema.GroupVersionKind{
+	Group:   "autoscaling.openshift.io",
+	Version: "v1",
+	Kind:    "ResourceOverride",
+}
+
+type OverrideResolver struct {
+	lister        ResourceOverrideLister
+	clusterConfig *Config
+	recorder      record.EventRecorder
+}
+
+func NewOverrideResolver(lister ResourceOverrideLister, clusterConfig *Config, recorder record.EventRecorder) *OverrideResolver {
+	return &OverrideResolver{
+		lister:        lister,
+		clusterConfig: clusterConfig,
+		recorder:      recorder,
+	}
+}
+
+func (r *OverrideResolver) ResolveConfig(namespace string, pod *corev1.Pod) *Config {
+	if r.lister == nil {
+		klog.V(5).Infof("namespace=%s ResourceOverride lister is nil, using ClusterResourceOverride config", namespace)
+		return r.clusterConfig
+	}
+
+	if pod == nil {
+		klog.Warningf("namespace=%s pod is nil, using ClusterResourceOverride config", namespace)
+		return r.clusterConfig
+	}
+
+	candidates, err := r.lister.ListByNamespace(namespace)
+	if err != nil {
+		klog.Warningf("namespace=%s failed to list ResourceOverrides: %v; falling back to ClusterResourceOverride config", namespace, err)
+		return r.clusterConfig
+	}
+
+	if len(candidates) == 0 {
+		klog.V(5).Infof("namespace=%s no ResourceOverrides found, using ClusterResourceOverride config", namespace)
+		return r.clusterConfig
+	}
+
+	podLabels := pod.Labels
+	if podLabels == nil {
+		podLabels = map[string]string{}
+	}
+
+	matched := filterMatchingROs(candidates, podLabels)
+	if len(matched) == 0 {
+		klog.V(5).Infof("namespace=%s no ResourceOverrides match pod labels, using ClusterResourceOverride config", namespace)
+		return r.clusterConfig
+	}
+
+	winner := r.selectWinner(matched, namespace, pod.Name)
+
+	config := ConvertExternalConfig(&ClusterResourceOverride{Spec: winner.Spec})
+	klog.V(5).Infof("namespace=%s using ResourceOverride %q config: %s", namespace, winner.Name, config)
+	return config
+}
+
+func filterMatchingROs(candidates []ResourceOverrideView, podLabels map[string]string) []ResourceOverrideView {
+	var matched []ResourceOverrideView
+	for _, ro := range candidates {
+		if IsNamespaceExempt(ro.Namespace) {
+			klog.V(5).Infof("namespace=%s ResourceOverride %q skipped: exempt namespace", ro.Namespace, ro.Name)
+			continue
+		}
+		if ro.Selector == nil || isEmptySelector(ro.Selector) {
+			matched = append(matched, ro)
+			continue
+		}
+		sel, err := metav1.LabelSelectorAsSelector(ro.Selector)
+		if err != nil {
+			klog.Warningf("namespace=%s ResourceOverride %q has invalid podSelector: %v; skipping", ro.Namespace, ro.Name, err)
+			continue
+		}
+		if sel.Matches(labels.Set(podLabels)) {
+			matched = append(matched, ro)
+		}
+	}
+	return matched
+}
+
+func isEmptySelector(sel *metav1.LabelSelector) bool {
+	return len(sel.MatchLabels) == 0 && len(sel.MatchExpressions) == 0
+}
+
+func (r *OverrideResolver) selectWinner(matched []ResourceOverrideView, namespace string, podName string) ResourceOverrideView {
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].Name < matched[j].Name
+	})
+
+	winner := matched[0]
+
+	if len(matched) > 1 {
+		for _, loser := range matched[1:] {
+			klog.Warningf("namespace=%s pod=%s matched multiple ResourceOverrides; %q selected, %q ignored",
+				namespace, podName, winner.Name, loser.Name)
+
+			if r.recorder != nil {
+				eventObj := roViewToEventObject(loser)
+				r.recorder.Eventf(eventObj, corev1.EventTypeWarning, "OverrideConflict",
+					"Pod %s/%s matched multiple ResourceOverrides; %q selected, %q ignored",
+					namespace, podName, winner.Name, loser.Name)
+			}
+		}
+	}
+
+	return winner
+}
+
+func roViewToEventObject(view ResourceOverrideView) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(resourceOverrideGVK)
+	u.SetNamespace(view.Namespace)
+	u.SetName(view.Name)
+	u.SetUID(view.UID)
+	return u
+}

--- a/pkg/clusterresourceoverride/resolver.go
+++ b/pkg/clusterresourceoverride/resolver.go
@@ -62,7 +62,7 @@ func (r *OverrideResolver) ResolveConfig(namespace string, pod *corev1.Pod) *Con
 		podLabels = map[string]string{}
 	}
 
-	matched := filterMatchingROs(candidates, podLabels)
+	matched := filterMatchingROs(candidates, namespace, podLabels)
 	if len(matched) == 0 {
 		klog.V(5).Infof("namespace=%s no ResourceOverrides match pod labels, using ClusterResourceOverride config", namespace)
 		return r.clusterConfig
@@ -75,9 +75,13 @@ func (r *OverrideResolver) ResolveConfig(namespace string, pod *corev1.Pod) *Con
 	return config
 }
 
-func filterMatchingROs(candidates []ResourceOverrideView, podLabels map[string]string) []ResourceOverrideView {
+func filterMatchingROs(candidates []ResourceOverrideView, podNamespace string, podLabels map[string]string) []ResourceOverrideView {
 	var matched []ResourceOverrideView
 	for _, ro := range candidates {
+		if ro.Namespace != podNamespace {
+			klog.Warningf("namespace=%s ResourceOverride %q skipped: belongs to namespace %q", podNamespace, ro.Name, ro.Namespace)
+			continue
+		}
 		if IsNamespaceExempt(ro.Namespace) {
 			klog.V(5).Infof("namespace=%s ResourceOverride %q skipped: exempt namespace", ro.Namespace, ro.Name)
 			continue

--- a/pkg/clusterresourceoverride/resolver_test.go
+++ b/pkg/clusterresourceoverride/resolver_test.go
@@ -1,0 +1,808 @@
+package clusterresourceoverride
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+var clusterConfig = &Config{
+	LimitCPUToMemoryRatio:     0.5,
+	CpuRequestToLimitRatio:    0.25,
+	MemoryRequestToLimitRatio: 0.5,
+}
+
+func makePod(name string, podLabels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: podLabels,
+		},
+	}
+}
+
+type fakeROLister struct {
+	views map[string][]ResourceOverrideView
+	err   error
+}
+
+func (f *fakeROLister) ListByNamespace(namespace string) ([]ResourceOverrideView, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.views[namespace], nil
+}
+
+func TestResolveConfig_NilStore(t *testing.T) {
+	resolver := NewOverrideResolver(nil, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.Equal(t, clusterConfig, got, "nil store should return cluster config")
+}
+
+func TestResolveConfig_StoreError(t *testing.T) {
+	store := &fakeROLister{err: fmt.Errorf("connection refused")}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.Equal(t, clusterConfig, got, "store error should fall back to cluster config")
+}
+
+func TestResolveConfig_NoROsInNamespace(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.Equal(t, clusterConfig, got, "no ROs should fall back to cluster config")
+}
+
+func TestResolveConfig_SingleMatchOverridesCluster(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-a",
+				Selector:  &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent:    80,
+					MemoryRequestToLimitPercent: 90,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	require.NotEqual(t, clusterConfig, got, "matching RO should override cluster config")
+	assert.InDelta(t, 0.8, got.CpuRequestToLimitRatio, 0.001)
+	assert.InDelta(t, 0.9, got.MemoryRequestToLimitRatio, 0.001)
+	assert.InDelta(t, 0.0, got.LimitCPUToMemoryRatio, 0.001)
+}
+
+func TestResolveConfig_NoMatchFallsBackToCluster(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-a",
+				Selector:  &metav1.LabelSelector{MatchLabels: map[string]string{"app": "backend"}},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 80,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.Equal(t, clusterConfig, got, "non-matching RO should fall back to cluster config")
+}
+
+func TestResolveConfig_EmptySelectorMatchesAllPods(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-all",
+				Selector:  &metav1.LabelSelector{},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 60,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 0.6, got.CpuRequestToLimitRatio, 0.001, "empty selector should match all pods")
+}
+
+func TestResolveConfig_NilSelectorMatchesAllPods(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-nil-sel",
+				Selector:  nil,
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 70,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 0.7, got.CpuRequestToLimitRatio, 0.001, "nil selector should match all pods")
+}
+
+func TestResolveConfig_MultipleMatches_FirstLexicographicallyWins(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-beta",
+				Selector:  nil,
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 90,
+				},
+			},
+			{
+				Namespace: "test-ns",
+				Name:      "override-alpha",
+				Selector:  nil,
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 50,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 0.5, got.CpuRequestToLimitRatio, 0.001,
+		"override-alpha (lexicographically first) should win with 50%%")
+}
+
+func TestResolveConfig_InvalidSelector_SkippedAndLogged(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "bad-selector",
+				Selector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOperator("InvalidOp"),
+							Values:   []string{"web"},
+						},
+					},
+				},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 99,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.Equal(t, clusterConfig, got, "invalid selector should be skipped, falling back to cluster config")
+}
+
+func TestResolveConfig_InvalidSelectorSkipped_ValidSelectorUsed(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "bad-selector",
+				Selector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "app",
+							Operator: metav1.LabelSelectorOperator("InvalidOp"),
+							Values:   []string{"web"},
+						},
+					},
+				},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 99,
+				},
+			},
+			{
+				Namespace: "test-ns",
+				Name:      "valid-selector",
+				Selector:  &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 40,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 0.4, got.CpuRequestToLimitRatio, 0.001,
+		"valid-selector should be used even when bad-selector is skipped")
+}
+
+func TestResolveConfig_PodWithNilLabels(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "specific-selector",
+				Selector:  &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 80,
+				},
+			},
+			{
+				Namespace: "test-ns",
+				Name:      "wildcard",
+				Selector:  nil,
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 60,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", nil)
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 0.6, got.CpuRequestToLimitRatio, 0.001,
+		"pod with nil labels should only match nil/empty selectors")
+}
+
+func TestResolveConfig_MatchExpressionsSelector(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "expr-override",
+				Selector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "env",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"staging", "dev"},
+						},
+					},
+				},
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 35,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{"env": "staging"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 0.35, got.CpuRequestToLimitRatio, 0.001,
+		"matchExpressions In should match")
+}
+
+func TestResolveConfig_AllSpecFields(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "full-override",
+				Selector:  nil,
+				Spec: ClusterResourceOverrideSpec{
+					LimitCPUToMemoryPercent:     200,
+					CPURequestToLimitPercent:    25,
+					MemoryRequestToLimitPercent: 50,
+					CPURequestToRequestPercent:  30,
+					ForceSelinuxRelabel:         true,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", nil)
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 2.0, got.LimitCPUToMemoryRatio, 0.001)
+	assert.InDelta(t, 0.25, got.CpuRequestToLimitRatio, 0.001)
+	assert.InDelta(t, 0.5, got.MemoryRequestToLimitRatio, 0.001)
+	assert.InDelta(t, 0.3, got.CpuRequestToRequestRatio, 0.001)
+	assert.True(t, got.ForceSelinuxRelabel)
+}
+
+func TestResolveConfig_ExemptNamespace_SkippedDuringSelection(t *testing.T) {
+	exemptNamespaces := []string{
+		"openshift-monitoring",
+		"openshift-ingress",
+		"kubernetes-system",
+		"kube-system",
+		"openshift",
+		"kubernetes",
+		"kube",
+	}
+
+	for _, ns := range exemptNamespaces {
+		t.Run(ns, func(t *testing.T) {
+			store := &fakeROLister{views: map[string][]ResourceOverrideView{
+				ns: {
+					{
+						Namespace: ns,
+						Name:      "override-in-exempt-ns",
+						Selector:  nil,
+						Spec: ClusterResourceOverrideSpec{
+							CPURequestToLimitPercent: 99,
+						},
+					},
+				},
+			}}
+			resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+			pod := makePod("test-pod", map[string]string{"app": "web"})
+			got := resolver.ResolveConfig(ns, pod)
+
+			assert.Equal(t, clusterConfig, got,
+				"ResourceOverride in exempt namespace %q should be skipped, falling back to cluster config", ns)
+		})
+	}
+}
+
+func TestResolveConfig_ExemptNamespaceRO_NonExemptROUsed(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"my-app": {
+			{
+				Namespace: "my-app",
+				Name:      "valid-override",
+				Selector:  nil,
+				Spec: ClusterResourceOverrideSpec{
+					CPURequestToLimitPercent: 60,
+				},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", nil)
+	got := resolver.ResolveConfig("my-app", pod)
+
+	assert.InDelta(t, 0.6, got.CpuRequestToLimitRatio, 0.001,
+		"non-exempt namespace RO should be used normally")
+}
+
+func TestFilterMatchingROs_ExemptNamespaceFiltered(t *testing.T) {
+	candidates := []ResourceOverrideView{
+		{Namespace: "openshift-monitoring", Name: "exempt-ro", Selector: nil},
+		{Namespace: "my-app", Name: "valid-ro", Selector: nil},
+		{Namespace: "kube-system", Name: "another-exempt", Selector: nil},
+	}
+	matched := filterMatchingROs(candidates, map[string]string{})
+	require.Len(t, matched, 1)
+	assert.Equal(t, "valid-ro", matched[0].Name)
+}
+
+func TestResolveConfig_NilPod(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-a",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 80},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	got := resolver.ResolveConfig("test-ns", nil)
+	assert.Equal(t, clusterConfig, got, "nil pod should fall back to cluster config without panicking")
+}
+
+func TestResolveConfig_NilClusterConfig(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{}}
+	resolver := NewOverrideResolver(store, nil, nil)
+
+	pod := makePod("test-pod", nil)
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.Nil(t, got, "nil clusterConfig should be returned as-is when no ROs match")
+}
+
+func TestResolveConfig_EmptyNamespace(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", nil)
+	got := resolver.ResolveConfig("", pod)
+
+	assert.Equal(t, clusterConfig, got, "empty namespace should fall back to cluster config")
+}
+
+func TestResolveConfig_PodWithEmptyLabelsMap(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "specific",
+				Selector:  &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 80},
+			},
+			{
+				Namespace: "test-ns",
+				Name:      "wildcard",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 60},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", map[string]string{})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 0.6, got.CpuRequestToLimitRatio, 0.001,
+		"empty labels map should behave same as nil labels")
+}
+
+func TestResolveConfig_CombinedMatchLabelsAndMatchExpressions(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "combined-selector",
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "web"},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod", "staging"}},
+					},
+				},
+				Spec: ClusterResourceOverrideSpec{CPURequestToLimitPercent: 45},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	t.Run("both match", func(t *testing.T) {
+		pod := makePod("pod1", map[string]string{"app": "web", "env": "prod"})
+		got := resolver.ResolveConfig("test-ns", pod)
+		assert.InDelta(t, 0.45, got.CpuRequestToLimitRatio, 0.001)
+	})
+
+	t.Run("labels match but expression does not", func(t *testing.T) {
+		pod := makePod("pod2", map[string]string{"app": "web", "env": "dev"})
+		got := resolver.ResolveConfig("test-ns", pod)
+		assert.Equal(t, clusterConfig, got)
+	})
+
+	t.Run("expression matches but label does not", func(t *testing.T) {
+		pod := makePod("pod3", map[string]string{"app": "api", "env": "prod"})
+		got := resolver.ResolveConfig("test-ns", pod)
+		assert.Equal(t, clusterConfig, got)
+	})
+}
+
+func TestResolveConfig_DoesNotExistExpression(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "no-gpu",
+				Selector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "gpu", Operator: metav1.LabelSelectorOpDoesNotExist},
+					},
+				},
+				Spec: ClusterResourceOverrideSpec{CPURequestToLimitPercent: 55},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	t.Run("label absent - matches", func(t *testing.T) {
+		pod := makePod("pod1", map[string]string{"app": "web"})
+		got := resolver.ResolveConfig("test-ns", pod)
+		assert.InDelta(t, 0.55, got.CpuRequestToLimitRatio, 0.001)
+	})
+
+	t.Run("label present - no match", func(t *testing.T) {
+		pod := makePod("pod2", map[string]string{"gpu": "true"})
+		got := resolver.ResolveConfig("test-ns", pod)
+		assert.Equal(t, clusterConfig, got)
+	})
+}
+
+func TestResolveConfig_CrossNamespaceROIgnored(t *testing.T) {
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "other-ns",
+				Name:      "cross-ns-ro",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 99},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, nil)
+
+	pod := makePod("test-pod", nil)
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	// The RO has Namespace="other-ns" even though it came from the "test-ns" query.
+	// Since "other-ns" is not exempt, it would still be used. This documents
+	// that the resolver trusts the store to return correct namespace results.
+	assert.InDelta(t, 0.99, got.CpuRequestToLimitRatio, 0.001)
+}
+
+func TestFilterMatchingROs_EmptyInput(t *testing.T) {
+	matched := filterMatchingROs(nil, map[string]string{"app": "web"})
+	assert.Empty(t, matched)
+}
+
+func TestFilterMatchingROs_EmptySliceInput(t *testing.T) {
+	matched := filterMatchingROs([]ResourceOverrideView{}, map[string]string{"app": "web"})
+	assert.Empty(t, matched)
+}
+
+func TestFilterMatchingROs_AllExempt(t *testing.T) {
+	candidates := []ResourceOverrideView{
+		{Namespace: "openshift-monitoring", Name: "ro1", Selector: nil},
+		{Namespace: "kube-system", Name: "ro2", Selector: nil},
+	}
+	matched := filterMatchingROs(candidates, map[string]string{})
+	assert.Empty(t, matched)
+}
+
+func TestFilterMatchingROs_NilPodLabels(t *testing.T) {
+	candidates := []ResourceOverrideView{
+		{Namespace: "test-ns", Name: "wildcard", Selector: nil},
+		{Namespace: "test-ns", Name: "specific", Selector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "web"},
+		}},
+	}
+	matched := filterMatchingROs(candidates, nil)
+	require.Len(t, matched, 1)
+	assert.Equal(t, "wildcard", matched[0].Name)
+}
+
+func newTestResolver(store ResourceOverrideLister, config *Config, recorder record.EventRecorder) *OverrideResolver {
+	return NewOverrideResolver(store, config, recorder)
+}
+
+func TestSelectWinner_SingleElement(t *testing.T) {
+	resolver := newTestResolver(nil, clusterConfig, nil)
+	input := []ResourceOverrideView{
+		{Name: "only-one", Spec: ClusterResourceOverrideSpec{CPURequestToLimitPercent: 50}},
+	}
+	winner := resolver.selectWinner(input, "ns", "pod")
+	assert.Equal(t, "only-one", winner.Name)
+}
+
+func TestSelectWinner_LexicographicOrder(t *testing.T) {
+	resolver := newTestResolver(nil, clusterConfig, nil)
+	input := []ResourceOverrideView{
+		{Name: "z-last"},
+		{Name: "a-first"},
+		{Name: "m-middle"},
+	}
+	winner := resolver.selectWinner(input, "ns", "pod")
+	assert.Equal(t, "a-first", winner.Name)
+}
+
+func TestSelectWinner_SamePrefix(t *testing.T) {
+	resolver := newTestResolver(nil, clusterConfig, nil)
+	input := []ResourceOverrideView{
+		{Name: "override-2"},
+		{Name: "override-10"},
+		{Name: "override-1"},
+	}
+	winner := resolver.selectWinner(input, "ns", "pod")
+	assert.Equal(t, "override-1", winner.Name, "lexicographic: '1' < '10' < '2'")
+}
+
+func TestResolveConfig_MultipleMatches_EmitsWarningEvent(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-beta",
+				UID:       "uid-beta",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 90},
+			},
+			{
+				Namespace: "test-ns",
+				Name:      "override-alpha",
+				UID:       "uid-alpha",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 50},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, fakeRecorder)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 0.5, got.CpuRequestToLimitRatio, 0.001,
+		"override-alpha should win")
+
+	select {
+	case event := <-fakeRecorder.Events:
+		assert.Contains(t, event, "Warning")
+		assert.Contains(t, event, "OverrideConflict")
+		assert.Contains(t, event, "override-beta")
+		assert.Contains(t, event, "test-pod")
+	default:
+		t.Fatal("expected a Warning event for multiple ResourceOverride matches, but none was emitted")
+	}
+}
+
+func TestResolveConfig_ThreeMatches_LexicographicWinner_EventListsAllIgnored(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-gamma",
+				UID:       "uid-gamma",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 30},
+			},
+			{
+				Namespace: "test-ns",
+				Name:      "override-alpha",
+				UID:       "uid-alpha",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 50},
+			},
+			{
+				Namespace: "test-ns",
+				Name:      "override-beta",
+				UID:       "uid-beta",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 70},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, fakeRecorder)
+
+	pod := makePod("my-pod", map[string]string{"app": "web"})
+	got := resolver.ResolveConfig("test-ns", pod)
+
+	assert.InDelta(t, 0.5, got.CpuRequestToLimitRatio, 0.001,
+		"override-alpha (lexicographically first) should win with 50%%")
+
+	// One event is fired per losing ResourceOverride (override-beta, override-gamma),
+	// not a single combined event, so drain both off the channel.
+	var events []string
+	for i := 0; i < 2; i++ {
+		select {
+		case event := <-fakeRecorder.Events:
+			events = append(events, event)
+		default:
+			t.Fatalf("expected 2 Warning events for 3-way ResourceOverride conflict, got %d", i)
+		}
+	}
+	combined := strings.Join(events, " | ")
+	assert.Contains(t, combined, "Warning")
+	assert.Contains(t, combined, "OverrideConflict")
+	assert.Contains(t, combined, "override-beta", "an event should reference ignored RO override-beta")
+	assert.Contains(t, combined, "override-gamma", "an event should reference ignored RO override-gamma")
+	assert.Contains(t, combined, "my-pod", "events should reference the pod name")
+}
+
+func TestSelectWinner_LexicographicOrder_EmitsEventWithAllIgnored(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	resolver := newTestResolver(nil, clusterConfig, fakeRecorder)
+	input := []ResourceOverrideView{
+		{Namespace: "ns", Name: "z-last", UID: "uid-z"},
+		{Namespace: "ns", Name: "a-first", UID: "uid-a"},
+		{Namespace: "ns", Name: "m-middle", UID: "uid-m"},
+	}
+	winner := resolver.selectWinner(input, "ns", "pod")
+	assert.Equal(t, "a-first", winner.Name, "lexicographically first should win")
+
+	// One event per loser (m-middle, z-last); the winner (a-first) is named as
+	// "selected" in each message but must never appear as the "ignored" party.
+	var events []string
+	for i := 0; i < 2; i++ {
+		select {
+		case event := <-fakeRecorder.Events:
+			events = append(events, event)
+		default:
+			t.Fatalf("expected 2 Warning events, got %d", i)
+		}
+	}
+	combined := strings.Join(events, " | ")
+	assert.Contains(t, combined, "m-middle", "an event should list ignored m-middle")
+	assert.Contains(t, combined, "z-last", "an event should list ignored z-last")
+	assert.NotContains(t, combined, `"a-first" ignored`, "winner should never appear as the ignored party")
+}
+
+func TestSelectWinner_SingleElement_NoEvent(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	resolver := newTestResolver(nil, clusterConfig, fakeRecorder)
+	input := []ResourceOverrideView{
+		{Namespace: "ns", Name: "only-one", UID: "uid-1"},
+	}
+	resolver.selectWinner(input, "ns", "pod")
+
+	select {
+	case event := <-fakeRecorder.Events:
+		t.Fatalf("expected no event for single element, but got: %s", event)
+	default:
+	}
+}
+
+func TestResolveConfig_SingleMatch_NoEvent(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	store := &fakeROLister{views: map[string][]ResourceOverrideView{
+		"test-ns": {
+			{
+				Namespace: "test-ns",
+				Name:      "override-only",
+				UID:       "uid-only",
+				Selector:  nil,
+				Spec:      ClusterResourceOverrideSpec{CPURequestToLimitPercent: 70},
+			},
+		},
+	}}
+	resolver := NewOverrideResolver(store, clusterConfig, fakeRecorder)
+
+	pod := makePod("test-pod", map[string]string{"app": "web"})
+	resolver.ResolveConfig("test-ns", pod)
+
+	select {
+	case event := <-fakeRecorder.Events:
+		t.Fatalf("expected no event for single match, but got: %s", event)
+	default:
+	}
+}
+
+func TestIsEmptySelector(t *testing.T) {
+	assert.True(t, isEmptySelector(&metav1.LabelSelector{}))
+	assert.True(t, isEmptySelector(&metav1.LabelSelector{
+		MatchLabels:      map[string]string{},
+		MatchExpressions: []metav1.LabelSelectorRequirement{},
+	}), "explicitly empty maps should also be considered empty")
+	assert.False(t, isEmptySelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{"a": "b"},
+	}))
+	assert.False(t, isEmptySelector(&metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "x", Operator: metav1.LabelSelectorOpExists},
+		},
+	}))
+}

--- a/pkg/clusterresourceoverride/resolver_test.go
+++ b/pkg/clusterresourceoverride/resolver_test.go
@@ -407,7 +407,7 @@ func TestFilterMatchingROs_ExemptNamespaceFiltered(t *testing.T) {
 		{Namespace: "my-app", Name: "valid-ro", Selector: nil},
 		{Namespace: "kube-system", Name: "another-exempt", Selector: nil},
 	}
-	matched := filterMatchingROs(candidates, map[string]string{})
+	matched := filterMatchingROs(candidates, "my-app", map[string]string{})
 	require.Len(t, matched, 1)
 	assert.Equal(t, "valid-ro", matched[0].Name)
 }
@@ -558,28 +558,25 @@ func TestResolveConfig_CrossNamespaceROIgnored(t *testing.T) {
 	pod := makePod("test-pod", nil)
 	got := resolver.ResolveConfig("test-ns", pod)
 
-	// The RO has Namespace="other-ns" even though it came from the "test-ns" query.
-	// Since "other-ns" is not exempt, it would still be used. This documents
-	// that the resolver trusts the store to return correct namespace results.
-	assert.InDelta(t, 0.99, got.CpuRequestToLimitRatio, 0.001)
+	assert.Equal(t, clusterConfig, got, "RO from a different namespace should be ignored, falling back to cluster config")
 }
 
 func TestFilterMatchingROs_EmptyInput(t *testing.T) {
-	matched := filterMatchingROs(nil, map[string]string{"app": "web"})
+	matched := filterMatchingROs(nil, "test-ns", map[string]string{"app": "web"})
 	assert.Empty(t, matched)
 }
 
 func TestFilterMatchingROs_EmptySliceInput(t *testing.T) {
-	matched := filterMatchingROs([]ResourceOverrideView{}, map[string]string{"app": "web"})
+	matched := filterMatchingROs([]ResourceOverrideView{}, "test-ns", map[string]string{"app": "web"})
 	assert.Empty(t, matched)
 }
 
 func TestFilterMatchingROs_AllExempt(t *testing.T) {
 	candidates := []ResourceOverrideView{
-		{Namespace: "openshift-monitoring", Name: "ro1", Selector: nil},
+		{Namespace: "kube-system", Name: "ro1", Selector: nil},
 		{Namespace: "kube-system", Name: "ro2", Selector: nil},
 	}
-	matched := filterMatchingROs(candidates, map[string]string{})
+	matched := filterMatchingROs(candidates, "kube-system", map[string]string{})
 	assert.Empty(t, matched)
 }
 
@@ -590,7 +587,7 @@ func TestFilterMatchingROs_NilPodLabels(t *testing.T) {
 			MatchLabels: map[string]string{"app": "web"},
 		}},
 	}
-	matched := filterMatchingROs(candidates, nil)
+	matched := filterMatchingROs(candidates, "test-ns", nil)
 	require.Len(t, matched, 1)
 	assert.Equal(t, "wildcard", matched[0].Name)
 }

--- a/pkg/clusterresourceoverride/resourceoverride_store.go
+++ b/pkg/clusterresourceoverride/resourceoverride_store.go
@@ -1,0 +1,183 @@
+package clusterresourceoverride
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// defaultResourceOverrideSyncTimeout bounds how long NewResourceOverrideLister waits for
+// the informer's initial sync. Without a bound, a missing ResourceOverride CRD causes the
+// informer's List/Watch calls to fail and retry forever, so cache.WaitForCacheSync (which
+// only returns early when stopCh fires) would block NewAdmission()/webhook startup indefinitely.
+const defaultResourceOverrideSyncTimeout = 30 * time.Second
+
+var resourceOverrideGVR = schema.GroupVersionResource{
+	Group:    "autoscaling.openshift.io",
+	Version:  "v1",
+	Resource: "resourceoverrides",
+}
+
+type ResourceOverrideView struct {
+	Namespace string
+	Name      string
+	UID       types.UID
+	Selector  *metav1.LabelSelector
+	Spec      ClusterResourceOverrideSpec
+}
+
+type ResourceOverrideLister interface {
+	ListByNamespace(namespace string) ([]ResourceOverrideView, error)
+}
+
+type resourceOverrideLister struct {
+	indexer cache.Indexer
+}
+
+func NewResourceOverrideLister(
+	dynFactory dynamicinformer.DynamicSharedInformerFactory,
+	stopCh <-chan struct{},
+) (ResourceOverrideLister, error) {
+	return newResourceOverrideListerWithTimeout(dynFactory, stopCh, defaultResourceOverrideSyncTimeout)
+}
+
+func newResourceOverrideListerWithTimeout(
+	dynFactory dynamicinformer.DynamicSharedInformerFactory,
+	stopCh <-chan struct{},
+	timeout time.Duration,
+) (ResourceOverrideLister, error) {
+	informer := dynFactory.ForResource(resourceOverrideGVR).Informer()
+	go informer.Run(stopCh)
+
+	if !waitForCacheSyncOrTimeout(stopCh, timeout, informer.HasSynced) {
+		return nil, fmt.Errorf("ResourceOverride informer sync failed or timed out after %s", timeout)
+	}
+
+	return &resourceOverrideLister{indexer: informer.GetIndexer()}, nil
+}
+
+// waitForCacheSyncOrTimeout bounds cache.WaitForCacheSync to timeout so a missing
+// ResourceOverride CRD (whose informer never syncs) cannot block startup indefinitely.
+// It still respects stopCh for a clean early exit on real shutdown.
+func waitForCacheSyncOrTimeout(stopCh <-chan struct{}, timeout time.Duration, hasSynced cache.InformerSynced) bool {
+	bounded := make(chan struct{})
+	timer := time.NewTimer(timeout)
+	go func() {
+		defer timer.Stop()
+		select {
+		case <-stopCh:
+		case <-timer.C:
+		}
+		close(bounded)
+	}()
+	return cache.WaitForCacheSync(bounded, hasSynced)
+}
+
+func NewResourceOverrideListerOrNil(kubeClientConfig *restclient.Config, stopCh <-chan struct{}) ResourceOverrideLister {
+	dynClient, err := dynamic.NewForConfig(kubeClientConfig)
+	if err != nil {
+		klog.Warningf("ResourceOverride informer disabled: %v", err)
+		return nil
+	}
+
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, defaultResyncPeriod, metav1.NamespaceAll, nil)
+	store, err := NewResourceOverrideLister(factory, stopCh)
+	if err != nil {
+		klog.Warningf("ResourceOverride informer disabled: %v", err)
+		return nil
+	}
+
+	return store
+}
+
+func (s *resourceOverrideLister) ListByNamespace(namespace string) ([]ResourceOverrideView, error) {
+	if s == nil || s.indexer == nil {
+		return nil, nil
+	}
+
+	items, err := s.indexer.ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]ResourceOverrideView, 0, len(items))
+	for _, item := range items {
+		u, ok := item.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		view, err := safeUnstructuredToROView(u)
+		if err != nil {
+			klog.Warningf("skip malformed ResourceOverride %s/%s: %v", namespace, u.GetName(), err)
+			continue
+		}
+		if IsNamespaceExempt(view.Namespace) {
+			continue
+		}
+		out = append(out, view)
+	}
+	return out, nil
+}
+
+// safeUnstructuredToROView wraps unstructuredToROView and converts any panic from the
+// unstructured helpers into an error, so ListByNamespace can skip the malformed entry
+// rather than crashing the webhook process (which would take down ClusterResourceOverride
+// admission too, not just ResourceOverride).
+func safeUnstructuredToROView(u *unstructured.Unstructured) (view ResourceOverrideView, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic decoding ResourceOverride: %v", r)
+		}
+	}()
+	return unstructuredToROView(u)
+}
+
+func unstructuredToROView(u *unstructured.Unstructured) (ResourceOverrideView, error) {
+	view := ResourceOverrideView{
+		Namespace: u.GetNamespace(),
+		Name:      u.GetName(),
+		UID:       u.GetUID(),
+	}
+
+	spec, found, err := unstructured.NestedMap(u.Object, "spec")
+	if err != nil || !found {
+		return view, fmt.Errorf("missing spec")
+	}
+
+	if selectorObj, ok := spec["podSelector"]; ok && selectorObj != nil {
+		selectorBytes, err := json.Marshal(selectorObj)
+		if err != nil {
+			return view, fmt.Errorf("failed to marshal podSelector: %v", err)
+		}
+		sel := &metav1.LabelSelector{}
+		if err := json.Unmarshal(selectorBytes, sel); err != nil {
+			return view, fmt.Errorf("failed to unmarshal podSelector: %v", err)
+		}
+		view.Selector = sel
+	}
+
+	override, found, err := unstructured.NestedMap(spec, "podResourceOverride")
+	if err != nil || !found {
+		return view, fmt.Errorf("missing podResourceOverride")
+	}
+
+	overrideBytes, err := json.Marshal(override)
+	if err != nil {
+		return view, fmt.Errorf("failed to marshal podResourceOverride: %v", err)
+	}
+	if err := json.Unmarshal(overrideBytes, &view.Spec); err != nil {
+		return view, fmt.Errorf("failed to unmarshal podResourceOverride: %v", err)
+	}
+
+	return view, nil
+}

--- a/pkg/clusterresourceoverride/resourceoverride_store.go
+++ b/pkg/clusterresourceoverride/resourceoverride_store.go
@@ -28,6 +28,7 @@ var resourceOverrideGVR = schema.GroupVersionResource{
 	Resource: "resourceoverrides",
 }
 
+// ResourceOverrideView is a decoded representation of a ResourceOverride CR from the informer cache.
 type ResourceOverrideView struct {
 	Namespace string
 	Name      string
@@ -36,6 +37,7 @@ type ResourceOverrideView struct {
 	Spec      ClusterResourceOverrideSpec
 }
 
+// ResourceOverrideLister lists ResourceOverride objects from the informer cache.
 type ResourceOverrideLister interface {
 	ListByNamespace(namespace string) ([]ResourceOverrideView, error)
 }
@@ -44,6 +46,7 @@ type resourceOverrideLister struct {
 	indexer cache.Indexer
 }
 
+// NewResourceOverrideLister starts the ResourceOverride informer and blocks until cache sync or timeout.
 func NewResourceOverrideLister(
 	dynFactory dynamicinformer.DynamicSharedInformerFactory,
 	stopCh <-chan struct{},
@@ -83,6 +86,7 @@ func waitForCacheSyncOrTimeout(stopCh <-chan struct{}, timeout time.Duration, ha
 	return cache.WaitForCacheSync(bounded, hasSynced)
 }
 
+// NewResourceOverrideListerOrNil returns a ResourceOverrideLister or nil if the CRD is missing or unreachable.
 func NewResourceOverrideListerOrNil(kubeClientConfig *restclient.Config, stopCh <-chan struct{}) ResourceOverrideLister {
 	dynClient, err := dynamic.NewForConfig(kubeClientConfig)
 	if err != nil {
@@ -100,6 +104,7 @@ func NewResourceOverrideListerOrNil(kubeClientConfig *restclient.Config, stopCh 
 	return store
 }
 
+// ListByNamespace returns decoded ResourceOverride objects in the given namespace, skipping exempt namespaces and malformed entries.
 func (s *resourceOverrideLister) ListByNamespace(namespace string) ([]ResourceOverrideView, error) {
 	if s == nil || s.indexer == nil {
 		return nil, nil

--- a/pkg/clusterresourceoverride/resourceoverride_store_test.go
+++ b/pkg/clusterresourceoverride/resourceoverride_store_test.go
@@ -48,7 +48,7 @@ func makeUnstructuredRO(namespace, name string, podSelector *metav1.LabelSelecto
 	if podSelector != nil {
 		selectorBytes, _ := json.Marshal(podSelector)
 		var selectorMap interface{}
-		json.Unmarshal(selectorBytes, &selectorMap)
+		_ = json.Unmarshal(selectorBytes, &selectorMap)
 		obj["spec"].(map[string]interface{})["podSelector"] = selectorMap
 	}
 	return &unstructured.Unstructured{Object: obj}
@@ -59,7 +59,7 @@ func newTestLister(objects ...*unstructured.Unstructured) *resourceOverrideListe
 		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
 	})
 	for _, obj := range objects {
-		indexer.Add(obj)
+		_ = indexer.Add(obj)
 	}
 	return &resourceOverrideLister{indexer: indexer}
 }
@@ -173,8 +173,8 @@ func TestListByNamespace_NonUnstructuredItemSkipped(t *testing.T) {
 	valid := makeUnstructuredRO("test-ns", "good-ro", nil, ClusterResourceOverrideSpec{
 		CPURequestToLimitPercent: 30,
 	})
-	indexer.Add(valid)
-	indexer.Add("not-an-unstructured-object")
+	_ = indexer.Add(valid)
+	_ = indexer.Add("not-an-unstructured-object")
 	store := &resourceOverrideLister{indexer: indexer}
 
 	results, err := store.ListByNamespace("test-ns")

--- a/pkg/clusterresourceoverride/resourceoverride_store_test.go
+++ b/pkg/clusterresourceoverride/resourceoverride_store_test.go
@@ -1,0 +1,509 @@
+package clusterresourceoverride
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+func makeUnstructuredROWithUID(namespace, name, uid string, podSelector *metav1.LabelSelector, spec ClusterResourceOverrideSpec) *unstructured.Unstructured {
+	u := makeUnstructuredRO(namespace, name, podSelector, spec)
+	u.Object["metadata"].(map[string]interface{})["uid"] = uid
+	return u
+}
+
+func makeUnstructuredRO(namespace, name string, podSelector *metav1.LabelSelector, spec ClusterResourceOverrideSpec) *unstructured.Unstructured {
+	obj := map[string]interface{}{
+		"apiVersion": "autoscaling.openshift.io/v1",
+		"kind":       "ResourceOverride",
+		"metadata": map[string]interface{}{
+			"namespace": namespace,
+			"name":      name,
+		},
+		"spec": map[string]interface{}{
+			"podResourceOverride": map[string]interface{}{
+				"limitCPUToMemoryPercent":     spec.LimitCPUToMemoryPercent,
+				"cpuRequestToLimitPercent":    spec.CPURequestToLimitPercent,
+				"memoryRequestToLimitPercent": spec.MemoryRequestToLimitPercent,
+				"cpuRequestToRequestPercent":  spec.CPURequestToRequestPercent,
+				"forceSelinuxRelabel":         spec.ForceSelinuxRelabel,
+			},
+		},
+	}
+	if podSelector != nil {
+		selectorBytes, _ := json.Marshal(podSelector)
+		var selectorMap interface{}
+		json.Unmarshal(selectorBytes, &selectorMap)
+		obj["spec"].(map[string]interface{})["podSelector"] = selectorMap
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func newTestLister(objects ...*unstructured.Unstructured) *resourceOverrideLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	for _, obj := range objects {
+		indexer.Add(obj)
+	}
+	return &resourceOverrideLister{indexer: indexer}
+}
+
+func TestListByNamespace_SingleMatch(t *testing.T) {
+	ro := makeUnstructuredRO("test-ns", "override-a", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+	store := newTestLister(ro)
+
+	results, err := store.ListByNamespace("test-ns")
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "override-a", results[0].Name)
+	assert.Equal(t, "test-ns", results[0].Namespace)
+	assert.Equal(t, int64(50), results[0].Spec.CPURequestToLimitPercent)
+}
+
+func TestListByNamespace_NoMatch(t *testing.T) {
+	ro := makeUnstructuredRO("other-ns", "override-a", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+	store := newTestLister(ro)
+
+	results, err := store.ListByNamespace("test-ns")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestListByNamespace_ExemptNamespaceSkipped(t *testing.T) {
+	ro := makeUnstructuredRO("openshift-monitoring", "override-a", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+	store := newTestLister(ro)
+
+	results, err := store.ListByNamespace("openshift-monitoring")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestListByNamespace_WithPodSelector(t *testing.T) {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "web"},
+	}
+	ro := makeUnstructuredRO("test-ns", "override-a", selector, ClusterResourceOverrideSpec{
+		MemoryRequestToLimitPercent: 75,
+	})
+	store := newTestLister(ro)
+
+	results, err := store.ListByNamespace("test-ns")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.NotNil(t, results[0].Selector)
+	assert.Equal(t, map[string]string{"app": "web"}, results[0].Selector.MatchLabels)
+	assert.Equal(t, int64(75), results[0].Spec.MemoryRequestToLimitPercent)
+}
+
+func TestListByNamespace_MultipleInSameNamespace(t *testing.T) {
+	roA := makeUnstructuredRO("test-ns", "override-a", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 25,
+	})
+	roB := makeUnstructuredRO("test-ns", "override-b", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+	store := newTestLister(roA, roB)
+
+	results, err := store.ListByNamespace("test-ns")
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+}
+
+func TestListByNamespace_NilStore(t *testing.T) {
+	store := &resourceOverrideLister{indexer: nil}
+
+	results, err := store.ListByNamespace("test-ns")
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+func TestListByNamespace_NilReceiver(t *testing.T) {
+	var store *resourceOverrideLister
+
+	results, err := store.ListByNamespace("test-ns")
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+func TestListByNamespace_MalformedObjectSkipped(t *testing.T) {
+	malformed := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"namespace": "test-ns",
+			"name":      "bad-ro",
+		},
+		"spec": map[string]interface{}{},
+	}}
+	valid := makeUnstructuredRO("test-ns", "good-ro", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+	store := newTestLister(malformed, valid)
+
+	results, err := store.ListByNamespace("test-ns")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "good-ro", results[0].Name)
+}
+
+func TestListByNamespace_NonUnstructuredItemSkipped(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	})
+	valid := makeUnstructuredRO("test-ns", "good-ro", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 30,
+	})
+	indexer.Add(valid)
+	indexer.Add("not-an-unstructured-object")
+	store := &resourceOverrideLister{indexer: indexer}
+
+	results, err := store.ListByNamespace("test-ns")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "good-ro", results[0].Name)
+}
+
+func TestUnstructuredToROView_MissingSpec(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"namespace": "test-ns",
+			"name":      "bad",
+		},
+	}}
+
+	_, err := unstructuredToROView(u)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing spec")
+}
+
+func TestUnstructuredToROView_SpecNotAMap(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"namespace": "test-ns",
+			"name":      "bad",
+		},
+		"spec": "not-a-map",
+	}}
+
+	_, err := unstructuredToROView(u)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing spec")
+}
+
+func TestUnstructuredToROView_NoPodSelector(t *testing.T) {
+	u := makeUnstructuredRO("test-ns", "no-sel", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+
+	view, err := unstructuredToROView(u)
+	require.NoError(t, err)
+	assert.Nil(t, view.Selector)
+	assert.Equal(t, int64(50), view.Spec.CPURequestToLimitPercent)
+}
+
+func TestUnstructuredToROView_ExplicitNullPodSelector(t *testing.T) {
+	u := makeUnstructuredRO("test-ns", "null-sel", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 40,
+	})
+	u.Object["spec"].(map[string]interface{})["podSelector"] = nil
+
+	view, err := unstructuredToROView(u)
+	require.NoError(t, err)
+	assert.Nil(t, view.Selector)
+	assert.Equal(t, int64(40), view.Spec.CPURequestToLimitPercent)
+}
+
+func TestUnstructuredToROView_PodSelectorWithMatchExpressions(t *testing.T) {
+	selector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "env",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"staging", "dev"},
+			},
+		},
+	}
+	u := makeUnstructuredRO("test-ns", "expr-sel", selector, ClusterResourceOverrideSpec{
+		MemoryRequestToLimitPercent: 60,
+	})
+
+	view, err := unstructuredToROView(u)
+	require.NoError(t, err)
+	require.NotNil(t, view.Selector)
+	require.Len(t, view.Selector.MatchExpressions, 1)
+	assert.Equal(t, "env", view.Selector.MatchExpressions[0].Key)
+	assert.Equal(t, metav1.LabelSelectorOpIn, view.Selector.MatchExpressions[0].Operator)
+	assert.Equal(t, []string{"staging", "dev"}, view.Selector.MatchExpressions[0].Values)
+}
+
+func TestUnstructuredToROView_MissingPodResourceOverrideSpec(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"namespace": "test-ns",
+			"name":      "no-override",
+		},
+		"spec": map[string]interface{}{},
+	}}
+
+	_, err := unstructuredToROView(u)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing podResourceOverride")
+}
+
+func TestUnstructuredToROView_EmptyPodResourceOverride(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"namespace": "test-ns",
+			"name":      "empty-override",
+		},
+		"spec": map[string]interface{}{
+			"podResourceOverride": map[string]interface{}{},
+		},
+	}}
+
+	view, err := unstructuredToROView(u)
+	require.NoError(t, err, "empty podResourceOverride is valid, all fields default to zero")
+	assert.Equal(t, int64(0), view.Spec.CPURequestToLimitPercent)
+	assert.Equal(t, int64(0), view.Spec.MemoryRequestToLimitPercent)
+}
+
+func TestUnstructuredToROView_MissingPodResourceOverrideKey(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"namespace": "test-ns",
+			"name":      "no-override-key",
+		},
+		"spec": map[string]interface{}{},
+	}}
+
+	_, err := unstructuredToROView(u)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing podResourceOverride")
+}
+
+func TestUnstructuredToROView_PartialSpecFields(t *testing.T) {
+	u := makeUnstructuredRO("test-ns", "partial", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 75,
+	})
+
+	view, err := unstructuredToROView(u)
+	require.NoError(t, err)
+	assert.Equal(t, int64(75), view.Spec.CPURequestToLimitPercent)
+	assert.Equal(t, int64(0), view.Spec.LimitCPUToMemoryPercent)
+	assert.Equal(t, int64(0), view.Spec.MemoryRequestToLimitPercent)
+	assert.Equal(t, int64(0), view.Spec.CPURequestToRequestPercent)
+	assert.False(t, view.Spec.ForceSelinuxRelabel)
+}
+
+func TestUnstructuredToROView_ZeroValueSpec(t *testing.T) {
+	u := makeUnstructuredRO("test-ns", "zero", nil, ClusterResourceOverrideSpec{})
+
+	view, err := unstructuredToROView(u)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), view.Spec.LimitCPUToMemoryPercent)
+	assert.Equal(t, int64(0), view.Spec.CPURequestToLimitPercent)
+	assert.Equal(t, int64(0), view.Spec.MemoryRequestToLimitPercent)
+	assert.Equal(t, int64(0), view.Spec.CPURequestToRequestPercent)
+	assert.False(t, view.Spec.ForceSelinuxRelabel)
+}
+
+func TestUnstructuredToROView_PodSelectorInvalidType(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "autoscaling.openshift.io/v1",
+		"kind":       "ResourceOverride",
+		"metadata": map[string]interface{}{
+			"namespace": "test-ns",
+			"name":      "bad-selector-type",
+		},
+		"spec": map[string]interface{}{
+			"podSelector": "not-a-map",
+			"podResourceOverride": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"cpuRequestToLimitPercent": int64(50),
+				},
+			},
+		},
+	}}
+
+	_, err := unstructuredToROView(u)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "podSelector")
+}
+
+func TestUnstructuredToROView_SpecFieldWrongType(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "autoscaling.openshift.io/v1",
+		"kind":       "ResourceOverride",
+		"metadata": map[string]interface{}{
+			"namespace": "test-ns",
+			"name":      "wrong-type",
+		},
+		"spec": map[string]interface{}{
+			"podResourceOverride": map[string]interface{}{
+				"cpuRequestToLimitPercent": "fifty",
+			},
+		},
+	}}
+
+	view, err := unstructuredToROView(u)
+	// json.Unmarshal into int64 from string "fifty" returns an error
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal")
+	_ = view
+}
+
+func TestUnstructuredToROView_PodResourceOverrideNotMap(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"namespace": "test-ns",
+			"name":      "bad-type",
+		},
+		"spec": map[string]interface{}{
+			"podResourceOverride": "not-a-map",
+		},
+	}}
+
+	_, err := unstructuredToROView(u)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing podResourceOverride")
+}
+
+func TestListByNamespace_EmptyNamespace(t *testing.T) {
+	ro := makeUnstructuredRO("test-ns", "ro-a", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+	store := newTestLister(ro)
+
+	results, err := store.ListByNamespace("")
+	require.NoError(t, err)
+	assert.Empty(t, results, "empty namespace should return no results")
+}
+
+func TestListByNamespace_MultipleExemptNamespacePrefixes(t *testing.T) {
+	ros := []*unstructured.Unstructured{
+		makeUnstructuredRO("openshift-operators", "ro1", nil, ClusterResourceOverrideSpec{CPURequestToLimitPercent: 50}),
+		makeUnstructuredRO("kube-public", "ro2", nil, ClusterResourceOverrideSpec{CPURequestToLimitPercent: 50}),
+		makeUnstructuredRO("kubernetes-dashboard", "ro3", nil, ClusterResourceOverrideSpec{CPURequestToLimitPercent: 50}),
+	}
+	store := newTestLister(ros...)
+
+	for _, ns := range []string{"openshift-operators", "kube-public", "kubernetes-dashboard"} {
+		results, err := store.ListByNamespace(ns)
+		require.NoError(t, err)
+		assert.Empty(t, results, "exempt namespace %s should be filtered", ns)
+	}
+}
+
+func TestUnstructuredToROView_AllFields(t *testing.T) {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"tier": "batch"},
+	}
+	u := makeUnstructuredRO("my-ns", "my-ro", selector, ClusterResourceOverrideSpec{
+		LimitCPUToMemoryPercent:     200,
+		CPURequestToLimitPercent:    25,
+		MemoryRequestToLimitPercent: 50,
+		CPURequestToRequestPercent:  30,
+		ForceSelinuxRelabel:         true,
+	})
+
+	view, err := unstructuredToROView(u)
+	require.NoError(t, err)
+	assert.Equal(t, "my-ns", view.Namespace)
+	assert.Equal(t, "my-ro", view.Name)
+	assert.Equal(t, map[string]string{"tier": "batch"}, view.Selector.MatchLabels)
+	assert.Equal(t, int64(200), view.Spec.LimitCPUToMemoryPercent)
+	assert.Equal(t, int64(25), view.Spec.CPURequestToLimitPercent)
+	assert.Equal(t, int64(50), view.Spec.MemoryRequestToLimitPercent)
+	assert.Equal(t, int64(30), view.Spec.CPURequestToRequestPercent)
+	assert.True(t, view.Spec.ForceSelinuxRelabel)
+}
+
+func TestUnstructuredToROView_UIDExtracted(t *testing.T) {
+	u := makeUnstructuredROWithUID("test-ns", "my-ro", "abc-123-uid", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+
+	view, err := unstructuredToROView(u)
+	require.NoError(t, err)
+	assert.Equal(t, types.UID("abc-123-uid"), view.UID)
+}
+
+func TestUnstructuredToROView_MissingUID(t *testing.T) {
+	u := makeUnstructuredRO("test-ns", "no-uid-ro", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+
+	view, err := unstructuredToROView(u)
+	require.NoError(t, err)
+	assert.Empty(t, view.UID, "missing UID should result in empty UID, not a panic")
+}
+
+func TestNewResourceOverrideLister_MissingCRD_DoesNotBlockStartup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, map[schema.GroupVersionResource]string{
+		resourceOverrideGVR: "ResourceOverrideList",
+	})
+
+	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: resourceOverrideGVR.Group, Resource: resourceOverrideGVR.Resource}, "")
+	dynClient.PrependReactor("list", "resourceoverrides", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, notFoundErr
+	})
+	dynClient.PrependWatchReactor("resourceoverrides", func(action clienttesting.Action) (bool, watch.Interface, error) {
+		return true, nil, notFoundErr
+	})
+
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(dynClient, time.Minute, metav1.NamespaceAll, nil)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	start := time.Now()
+	store, err := newResourceOverrideListerWithTimeout(factory, stopCh, 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	assert.Nil(t, store, "missing CRD should soft-fail to a nil store, not a usable one")
+	assert.Error(t, err)
+	assert.Less(t, elapsed, 2*time.Second,
+		"sync should time out quickly when the CRD is missing, not block webhook startup indefinitely")
+}
+
+func TestSafeUnstructuredToROView_RecoversFromPanic(t *testing.T) {
+	// A nil *unstructured.Unstructured panics inside u.GetNamespace() (nil pointer
+	// dereference). safeUnstructuredToROView must convert that into an error so a
+	// single malformed/unexpected cache entry can't crash the whole webhook process.
+	assert.NotPanics(t, func() {
+		_, err := safeUnstructuredToROView(nil)
+		assert.Error(t, err, "a nil unstructured object should produce an error, not a panic")
+	})
+}
+
+func TestListByNamespace_UIDPreserved(t *testing.T) {
+	ro := makeUnstructuredROWithUID("test-ns", "override-a", "uid-456", nil, ClusterResourceOverrideSpec{
+		CPURequestToLimitPercent: 50,
+	})
+	store := newTestLister(ro)
+
+	results, err := store.ListByNamespace("test-ns")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, types.UID("uid-456"), results[0].UID)
+}


### PR DESCRIPTION
Implements the operand side of [RFE-9093](https://redhat.atlassian.net/browse/RFE-9093): namespaced ResourceOverride objects with podSelector-based targeting, resolved ahead of ClusterResourceOverride at pod admission (AUTOSCALE-867, 868, 869).

- Add a dynamic informer/lister for ResourceOverride (resourceoverride_store.go). Soft-fails to nil with a bounded sync timeout if the CRD is missing, so a missing CRD can never block webhook startup; malformed cache entries are skipped via a panic-recovering decode wrapper instead of crashing the process.
- Add OverrideResolver (resolver.go): resolves the effective override config per pod by listing ResourceOverride objects in the pod's namespace, filtering by podSelector (empty selector matches all pods), and picking the lexicographically-first name on multiple matches. Falls back to ClusterResourceOverride when there's no lister, no candidates, or no selector match. Multiple matches emit a Warning Event (reason OverrideConflict) on each losing ResourceOverride referencing the pod and the winner, without ever blocking admission.
- Wire the lister and resolver into NewAdmission()/Admit() in admission.go; existing Namespace and LimitRange informers are unchanged.
- Reuse IsNamespaceExempt() to skip ResourceOverride objects in exempt namespaces during lookup (defense in depth alongside operator-side validation).

Unit tests cover: podSelector matching (empty/nil/matchLabels/ matchExpressions), lexicographic tie-break and conflict events, exempt namespace filtering, nil-lister/store-error/no-match fallback paths, missing CRD not blocking startup, and unstructured decode edge cases (malformed, partial, non-unstructured cache items).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admission now uses per-namespace/per-pod effective settings resolved from matching resource overrides.
  * Empty selectors now match all pods, and when multiple overrides match, selection is deterministic.
  * When multiple overrides match, warning events are emitted for the non-selected overrides; behavior falls back to cluster-level settings when no match is found (or overrides can’t be resolved).
* **Bug Fixes**
  * Malformed pod input is rejected with an HTTP 400 response.
* **Tests**
  * Expanded unit test coverage for override resolution, exemption logic, selector matching, and admission mutation/patching (including LimitRange and CPU/request scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->