### PR TITLE
Fix float64 truncation in the CPU override paths

### DIFF
--- a/pkg/clusterresourceoverride/mutator.go
+++ b/pkg/clusterresourceoverride/mutator.go
@@ -16,6 +16,11 @@ type CPUMemory struct {
 	Memory *resource.Quantity
 }
 
+// NewMutator returns a podMutator for the given configuration, namespace floor, and ceiling.
+// It rejects nil inputs and a non-finite scale factor or ratio; range validation of the ratios
+// is the configuration loader's responsibility. The mutator retains the config, minimum, and
+// maximum it is given rather than copying them, so a caller must not mutate those values after
+// construction. The admission handler satisfies this by building a fresh set for each request.
 func NewMutator(config *Config, minimum *CPUMemory, maximum *CPUMemory, cpuBaseScaleFactor float64) (mutator *podMutator, err error) {
 	if config == nil || minimum == nil || maximum == nil {
 		err = errors.New("NewMutator: invalid input")

--- a/pkg/clusterresourceoverride/mutator.go
+++ b/pkg/clusterresourceoverride/mutator.go
@@ -3,6 +3,8 @@ package clusterresourceoverride
 import (
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -18,6 +20,28 @@ func NewMutator(config *Config, minimum *CPUMemory, maximum *CPUMemory, cpuBaseS
 	if config == nil || minimum == nil || maximum == nil {
 		err = errors.New("NewMutator: invalid input")
 		return
+	}
+	if math.IsNaN(cpuBaseScaleFactor) || math.IsInf(cpuBaseScaleFactor, 0) || cpuBaseScaleFactor < 0 {
+		err = fmt.Errorf("NewMutator: cpuBaseScaleFactor must be finite and non-negative, got %v", cpuBaseScaleFactor)
+		return
+	}
+	// Reject a non-finite ratio here rather than letting it reach the arithmetic, where a
+	// NaN would otherwise be quietly treated as 0%. A Config from ConvertExternalConfig
+	// cannot be non-finite (the external percentages are int64); this guards a Config built
+	// directly. Range validation of the ratios lives in the configuration loader.
+	for _, r := range []struct {
+		name  string
+		ratio float64
+	}{
+		{"LimitCPUToMemoryRatio", config.LimitCPUToMemoryRatio},
+		{"CpuRequestToLimitRatio", config.CpuRequestToLimitRatio},
+		{"MemoryRequestToLimitRatio", config.MemoryRequestToLimitRatio},
+		{"CpuRequestToRequestRatio", config.CpuRequestToRequestRatio},
+	} {
+		if math.IsNaN(r.ratio) || math.IsInf(r.ratio, 0) {
+			err = fmt.Errorf("NewMutator: %s must be finite, got %v", r.name, r.ratio)
+			return
+		}
 	}
 
 	mutator = &podMutator{
@@ -176,6 +200,69 @@ func (m *podMutator) OverrideMemory(resources *corev1.ResourceRequirements) {
 	resources.Requests[corev1.ResourceMemory] = *overridden
 }
 
+// saturatingRoundedPercent rounds ratio*100 to the nearest integer percent and returns it
+// as an int64, clamping at the int64 bounds. An out-of-range float64-to-int64 conversion is
+// implementation-dependent (the Go spec does not guarantee it wraps) and can yield a
+// negative value, which would then produce a negative CPU quantity instead of saturating; a
+// NaN ratio (only reachable from a directly built Config) becomes 0 rather than an arbitrary
+// int64.
+func saturatingRoundedPercent(ratio float64) int64 {
+	p := math.Round(ratio * 100)
+	switch {
+	case math.IsNaN(p):
+		return 0
+	case p >= float64(math.MaxInt64):
+		return math.MaxInt64
+	case p <= float64(math.MinInt64):
+		return math.MinInt64
+	default:
+		return int64(p)
+	}
+}
+
+// saturatingInt64 returns n as an int64, clamping to the int64 range when n does not fit.
+// math/big's Int64 is undefined for an out-of-range value, so the magnitude must be gated
+// first; the CPU amounts computed here are non-negative in normal operation, and an
+// out-of-range magnitude saturates to the nearest int64 bound.
+func saturatingInt64(n *big.Int) int64 {
+	if n.IsInt64() {
+		return n.Int64()
+	}
+	if n.Sign() < 0 {
+		return math.MinInt64
+	}
+	return math.MaxInt64
+}
+
+// recoverWholePercent recovers the whole-number percent that a ratio (stored as percent/100)
+// represents, and reports whether the ratio is exactly that whole percent. ConvertExternalConfig
+// builds float64(percent)/100 from an int64 percentage, so every request percentage in [0,100]
+// and every practical CPU-to-memory percentage takes the exact integer-percent path; a Config
+// built directly with a fractional ratio such as 0.005 does not, and is scaled linearly instead
+// of being rounded to a percent. (An astronomically large CPU-to-memory percentage can recover a
+// slightly different whole percent through the float64 round-trip and still report whole; exact
+// handling of the full unbounded int64 percentage is tracked in #115.)
+func recoverWholePercent(ratio float64) (pct int64, whole bool) {
+	pct = saturatingRoundedPercent(ratio)
+	return pct, ratio == float64(pct)/100
+}
+
+// saturatingTruncFloat64 converts v to an int64, truncating toward zero (the historical
+// behavior) and clamping to the int64 range. An out-of-range float64-to-int64 conversion is
+// implementation-dependent in Go, so the magnitude is gated first; a NaN becomes 0.
+func saturatingTruncFloat64(v float64) int64 {
+	switch {
+	case math.IsNaN(v):
+		return 0
+	case v >= float64(math.MaxInt64):
+		return math.MaxInt64
+	case v <= float64(math.MinInt64):
+		return math.MinInt64
+	default:
+		return int64(v)
+	}
+}
+
 // If a container memory limit has been specified or defaulted, the CPU limit is
 // overridden to a percentage of the memory limit, with a 100 percentage scaling
 // 1Gi of RAM to equal 1 CPU core. This is processed prior to overriding CPU
@@ -190,8 +277,27 @@ func (m *podMutator) OverrideCPULimit(resources *corev1.ResourceRequirements) {
 		return
 	}
 
-	amount := float64(limit.Value()) * m.config.LimitCPUToMemoryRatio * m.cpuBaseScaleFactor
-	overridden := resource.NewMilliQuantity(int64(amount), resource.DecimalSI)
+	// A whole-number percent (every value ConvertExternalConfig produces) is applied exactly:
+	// scale the memory bytes to millicores by cpuBaseScaleFactor's exact rational form and do
+	// the multiply/divide in big.Int, so the result is the exact floor (the historical
+	// truncating behavior) rather than a float64 approximation (a 1536Mi limit at 29% is 435m,
+	// not the 434m a float cast produces), and a result past int64 saturates instead of
+	// wrapping. The default cpuBaseScaleFactor 1000/2^30 is exactly representable as a float64,
+	// so this path is exact for the production configuration; the unbounded-percentage exact
+	// case is tracked in #115. A ratio that is not a whole percent is only reachable from a
+	// directly built Config and is scaled linearly (historical behavior) rather than rounded to
+	// a percent.
+	var amount int64
+	if pct, whole := recoverWholePercent(m.config.LimitCPUToMemoryRatio); whole {
+		scale := new(big.Rat).SetFloat64(m.cpuBaseScaleFactor) // finite and non-negative: validated in NewMutator
+		amountBig := new(big.Int).Mul(big.NewInt(limit.Value()), big.NewInt(pct))
+		amountBig.Mul(amountBig, scale.Num())
+		amountBig.Quo(amountBig, new(big.Int).Mul(big.NewInt(100), scale.Denom()))
+		amount = saturatingInt64(amountBig)
+	} else {
+		amount = saturatingTruncFloat64(float64(limit.Value()) * m.config.LimitCPUToMemoryRatio * m.cpuBaseScaleFactor)
+	}
+	overridden := resource.NewMilliQuantity(amount, resource.DecimalSI)
 	if m.IsCpuFloorSpecified() && overridden.Cmp(*m.floor.CPU) < 0 {
 		klog.V(5).Infof("%s pod limit %q below namespace limit; setting limit to %q", corev1.ResourceCPU, overridden.String(), m.floor.CPU.String())
 
@@ -222,8 +328,22 @@ func (m *podMutator) OverrideCPUWithLimit(resources *corev1.ResourceRequirements
 		return
 	}
 
-	amount := float64(limit.MilliValue()) * m.config.CpuRequestToLimitRatio
-	overridden := resource.NewMilliQuantity(int64(amount), limit.Format)
+	// CpuRequestToLimitRatio is stored as a float64 (percent/100). A whole-number percent is
+	// applied in big.Int so an exact-integer result is not lost to a truncating float cast
+	// (100m at 29% is float64(100)*0.29 = 28.999... -> 28m with a plain cast; big.Int gives
+	// 29m); a ratio that is not a whole percent (only reachable from a directly built Config)
+	// is scaled linearly, matching the historical behavior for such a value. Both paths
+	// saturate the int64 conversion. This assumes limit.MilliValue() has not itself overflowed
+	// int64, a pre-existing edge for an astronomically large Pod CPU quantity tracked in #115.
+	var amount int64
+	if pct, whole := recoverWholePercent(m.config.CpuRequestToLimitRatio); whole {
+		amountBig := new(big.Int).Mul(big.NewInt(limit.MilliValue()), big.NewInt(pct))
+		amountBig.Quo(amountBig, big.NewInt(100))
+		amount = saturatingInt64(amountBig)
+	} else {
+		amount = saturatingTruncFloat64(float64(limit.MilliValue()) * m.config.CpuRequestToLimitRatio)
+	}
+	overridden := resource.NewMilliQuantity(amount, limit.Format)
 
 	if m.IsCpuFloorSpecified() && overridden.Cmp(*m.floor.CPU) < 0 {
 		klog.V(5).Infof("%s pod request %q below namespace minimum; setting request to %q", corev1.ResourceCPU, overridden.String(), m.floor.CPU.String())
@@ -265,8 +385,19 @@ func (m *podMutator) OverrideCPUWithRequest(resources *corev1.ResourceRequiremen
 		return
 	}
 
-	amount := float64(request.MilliValue()) * m.config.CpuRequestToRequestRatio
-	overridden := resource.NewMilliQuantity(int64(amount), request.Format)
+	// Same whole-percent-vs-fractional split as OverrideCPUWithLimit: a whole percent is applied
+	// exactly in big.Int, a fractional ratio (only from a directly built Config) is scaled
+	// linearly, and the conversion saturates. As above, this assumes request.MilliValue() has
+	// not itself overflowed int64.
+	var amount int64
+	if pct, whole := recoverWholePercent(m.config.CpuRequestToRequestRatio); whole {
+		amountBig := new(big.Int).Mul(big.NewInt(request.MilliValue()), big.NewInt(pct))
+		amountBig.Quo(amountBig, big.NewInt(100))
+		amount = saturatingInt64(amountBig)
+	} else {
+		amount = saturatingTruncFloat64(float64(request.MilliValue()) * m.config.CpuRequestToRequestRatio)
+	}
+	overridden := resource.NewMilliQuantity(amount, request.Format)
 
 	if m.IsCpuFloorSpecified() && overridden.Cmp(*m.floor.CPU) < 0 {
 		klog.V(5).Infof("%s pod request %q below namespace minimum; setting request to %q", corev1.ResourceCPU, overridden.String(), m.floor.CPU.String())

--- a/pkg/clusterresourceoverride/mutator.go
+++ b/pkg/clusterresourceoverride/mutator.go
@@ -277,7 +277,8 @@ func (m *podMutator) OverrideCPULimit(resources *corev1.ResourceRequirements) {
 		return
 	}
 
-	// A whole-number percent (every value ConvertExternalConfig produces) is applied exactly:
+	// A whole-number percent (every practical CPU-to-memory percentage ConvertExternalConfig
+	// produces) is applied exactly:
 	// scale the memory bytes to millicores by cpuBaseScaleFactor's exact rational form and do
 	// the multiply/divide in big.Int, so the result is the exact floor (the historical
 	// truncating behavior) rather than a float64 approximation (a 1536Mi limit at 29% is 435m,

--- a/pkg/clusterresourceoverride/mutator_test.go
+++ b/pkg/clusterresourceoverride/mutator_test.go
@@ -1321,3 +1321,46 @@ func TestNewMutator_RejectsNonFiniteRatio(t *testing.T) {
 	_, err := NewMutator(&Config{LimitCPUToMemoryRatio: 2.0}, &CPUMemory{}, &CPUMemory{}, factor)
 	assert.NoError(t, err)
 }
+
+func TestOverridePreservesExactPercentThroughConversion(t *testing.T) {
+	// End to end: a whole-number percent from the operator CRD keeps its exact integer
+	// arithmetic through ConvertExternalConfig -> NewMutator -> Mutate, rather than losing the
+	// last millicore to a truncating float cast. Config.Validate is added in #118 and joins
+	// this chain once that merges; the conversion and mutation steps are what this PR changes.
+	podWithLimits := func(limits corev1.ResourceList) *corev1.Pod {
+		return &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:      "app",
+					Resources: corev1.ResourceRequirements{Limits: limits},
+				}},
+			},
+		}
+	}
+
+	t.Run("CPU-to-memory scales a memory limit to an exact CPU limit", func(t *testing.T) {
+		cro := &ClusterResourceOverride{Spec: ClusterResourceOverrideSpec{LimitCPUToMemoryPercent: 29}}
+		mutator, err := NewMutator(ConvertExternalConfig(cro), &CPUMemory{}, &CPUMemory{}, factor)
+		require.NoError(t, err)
+
+		out, err := mutator.Mutate(podWithLimits(corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1536Mi")}))
+		require.NoError(t, err)
+
+		// 1536Mi is 1.5GiB, so 1.5 * 1000 mCPU * 29% is exactly 435m; a float cast yields 434m.
+		got := out.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
+		assert.Equal(t, "435m", got.String())
+	})
+
+	t.Run("CPU-request-to-limit sets an exact CPU request", func(t *testing.T) {
+		cro := &ClusterResourceOverride{Spec: ClusterResourceOverrideSpec{CPURequestToLimitPercent: 29}}
+		mutator, err := NewMutator(ConvertExternalConfig(cro), &CPUMemory{}, &CPUMemory{}, factor)
+		require.NoError(t, err)
+
+		out, err := mutator.Mutate(podWithLimits(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}))
+		require.NoError(t, err)
+
+		// 100m * 29% is exactly 29m; float64(100)*0.29 is 28.999... and truncates to 28m.
+		got := out.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+		assert.Equal(t, "29m", got.String())
+	})
+}

--- a/pkg/clusterresourceoverride/mutator_test.go
+++ b/pkg/clusterresourceoverride/mutator_test.go
@@ -2,6 +2,7 @@ package clusterresourceoverride
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,10 +17,10 @@ const (
 )
 
 func TestMutator_Mutate(t *testing.T) {
-	
+
 	cpu := resource.MustParse("1m")
 	memory := resource.MustParse("1Mi")
-	
+
 	// Tests the mutator using CPURequestToLimitRatio as the CPU request override
 	t.Run("WithCpuRequestToLimitRatio", func(t *testing.T) {
 		floor := &CPUMemory{
@@ -92,11 +93,11 @@ func TestMutator_Mutate(t *testing.T) {
 		validate(t, podGot.Spec.Containers[1].Resources.Limits, corev1.ResourceCPU, resource.MustParse("4000m"))
 		validate(t, podGot.Spec.Containers[1].Resources.Requests, corev1.ResourceCPU, resource.MustParse("1000m"))
 	})
-	
+
 	// Tests mutator using CPURequestToRequestRatio as the CPU resource override
 	// Ensures CPURequestToRequestRatio overwrites CPURequestToLimitRatio
 	// Ensures CPURequestToRequestRatio doesn't compute with request from CPURequestToLimitRatio
-	// Tests the per container annotations to ensure the mutator applies the override 
+	// Tests the per container annotations to ensure the mutator applies the override
 	//   according to each container's original request
 	t.Run("WithCpuRequestToRequestRatio", func(t *testing.T) {
 		floor := &CPUMemory{
@@ -319,7 +320,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 	testAnnotation := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, testContainerName)
 	tests := []struct {
 		name    string
-		pod *corev1.Pod
+		pod     *corev1.Pod
 		mutator func() *podMutator
 		input   *corev1.ResourceRequirements
 		assert  func(t *testing.T, resources *corev1.ResourceRequirements)
@@ -330,7 +331,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -354,7 +355,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 				},
 			},
 			mutator: func() *podMutator {
@@ -376,7 +377,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -402,7 +403,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -430,7 +431,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "1000m",
 					},
@@ -460,7 +461,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -490,7 +491,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "1000m",
 					},
@@ -1084,4 +1085,239 @@ func validate(t *testing.T, list corev1.ResourceList, name corev1.ResourceName, 
 
 	result := got.Equal(want)
 	require.True(t, result, "mutated, expected: %v, got %v", want, got)
+}
+
+// TestMutator_CPUOverridesDoNotUndercountFractionalPercent covers the float64
+// truncation across the three CPU override paths. 29% is the canonical case:
+// float64(x)*0.29 is 28.999999999999996, so a plain int64 cast dropped the result
+// by 1m. Each path is exercised through the real config conversion.
+func TestMutator_CPUOverridesDoNotUndercountFractionalPercent(t *testing.T) {
+	t.Run("OverrideCPUWithLimit", func(t *testing.T) {
+		m := &podMutator{config: ConvertExternalConfig(&ClusterResourceOverride{
+			Spec: ClusterResourceOverrideSpec{CPURequestToLimitPercent: 29},
+		})}
+		res := &corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+		}
+		m.OverrideCPUWithLimit(res)
+		validate(t, res.Requests, corev1.ResourceCPU, resource.MustParse("29m"))
+	})
+
+	t.Run("OverrideCPUWithRequest", func(t *testing.T) {
+		m := &podMutator{config: ConvertExternalConfig(&ClusterResourceOverride{
+			Spec: ClusterResourceOverrideSpec{CPURequestToRequestPercent: 29},
+		})}
+		name := "c"
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, name): "100m",
+		}}}
+		res := &corev1.ResourceRequirements{}
+		m.OverrideCPUWithRequest(res, name, pod)
+		validate(t, res.Requests, corev1.ResourceCPU, resource.MustParse("29m"))
+	})
+
+	t.Run("OverrideCPULimit", func(t *testing.T) {
+		m := &podMutator{
+			config: ConvertExternalConfig(&ClusterResourceOverride{
+				Spec: ClusterResourceOverrideSpec{LimitCPUToMemoryPercent: 29},
+			}),
+			cpuBaseScaleFactor: factor,
+		}
+		res := &corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1536Mi")},
+		}
+		m.OverrideCPULimit(res)
+		validate(t, res.Limits, corev1.ResourceCPU, resource.MustParse("435m"))
+	})
+}
+
+// TestMutator_CPUOverridesPreserveProgrammaticFractionalRatio covers a Config built directly
+// with a ratio that is not a whole-number percent. This is only reachable programmatically
+// (ConvertExternalConfig always yields a multiple of 0.01 from its int64 percentage), and
+// #118's Config.Validate accepts the full [0,1] range, so the mutator scales such a ratio
+// linearly instead of rounding it to the nearest percent: 0.5% of 1000m is 5m, not 10m.
+func TestMutator_CPUOverridesPreserveProgrammaticFractionalRatio(t *testing.T) {
+	t.Run("OverrideCPUWithLimit is linear, not rounded", func(t *testing.T) {
+		m := &podMutator{config: &Config{CpuRequestToLimitRatio: 0.005}}
+		res := &corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1000m")},
+		}
+		m.OverrideCPUWithLimit(res)
+		validate(t, res.Requests, corev1.ResourceCPU, resource.MustParse("5m"))
+	})
+
+	t.Run("OverrideCPUWithLimit floors a fractional product", func(t *testing.T) {
+		// 33.33% of 1000m is 333.3m, floored to 333m (a round-to-33% would give 330m).
+		m := &podMutator{config: &Config{CpuRequestToLimitRatio: 0.3333}}
+		res := &corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1000m")},
+		}
+		m.OverrideCPUWithLimit(res)
+		validate(t, res.Requests, corev1.ResourceCPU, resource.MustParse("333m"))
+	})
+
+	t.Run("OverrideCPUWithRequest is linear, not rounded", func(t *testing.T) {
+		m := &podMutator{config: &Config{CpuRequestToRequestRatio: 0.005}}
+		name := "c"
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, name): "1000m",
+		}}}
+		res := &corev1.ResourceRequirements{}
+		m.OverrideCPUWithRequest(res, name, pod)
+		validate(t, res.Requests, corev1.ResourceCPU, resource.MustParse("5m"))
+	})
+
+	t.Run("OverrideCPULimit is linear, not rounded", func(t *testing.T) {
+		// 1Gi is exactly 2^30 bytes and the default factor is 1000/2^30, so the size cancels
+		// and 0.5% yields 5m (a round-to-1% would give 10m).
+		m := &podMutator{config: &Config{LimitCPUToMemoryRatio: 0.005}, cpuBaseScaleFactor: factor}
+		res := &corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+		}
+		m.OverrideCPULimit(res)
+		validate(t, res.Limits, corev1.ResourceCPU, resource.MustParse("5m"))
+	})
+}
+
+func TestMutator_OverrideCPULimitFloorsExactly(t *testing.T) {
+	// OverrideCPULimit does an exact integer division and floors it. These lock both
+	// halves: the truncation fix (1536Mi at 29% is exactly 435m, previously lost to
+	// float64 error as 434m) and the floor policy (768Mi at 29% is exactly 217.5m,
+	// which floors to 217m rather than rounding up to 218m; 1538Mi at 29% floors to
+	// 435m, not 436m).
+	cases := []struct {
+		name   string
+		memory string
+		pct    int64
+		want   string
+	}{
+		{"exact integer result is not lost to float64 error", "1536Mi", 29, "435m"},
+		{"fractional result floors down", "1538Mi", 29, "435m"},
+		{"exact half floors down", "768Mi", 29, "217m"},
+		{"high percent floors down", "88Mi", 96, "82m"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &podMutator{
+				config: ConvertExternalConfig(&ClusterResourceOverride{
+					Spec: ClusterResourceOverrideSpec{LimitCPUToMemoryPercent: c.pct},
+				}),
+				cpuBaseScaleFactor: factor,
+			}
+			res := &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(c.memory)},
+			}
+			m.OverrideCPULimit(res)
+			validate(t, res.Limits, corev1.ResourceCPU, resource.MustParse(c.want))
+		})
+	}
+}
+
+func TestMutator_OverrideCPULimitSaturates(t *testing.T) {
+	// A percent near the int64 ceiling produces an exact large result rather than a wrapped
+	// negative one, and a result past int64 saturates to MaxInt64. Asserting the exact value
+	// (not just non-negative) also catches a recovered percent that is merely off by a little.
+	cases := []struct {
+		name   string
+		memory string
+		pct    int64
+		want   int64
+	}{
+		{"max percent within int64 floors exactly", "1Mi", math.MaxInt64, 90071992547409919},
+		{"max percent past int64 saturates", "1Gi", math.MaxInt64, math.MaxInt64},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			m := &podMutator{
+				config: ConvertExternalConfig(&ClusterResourceOverride{
+					Spec: ClusterResourceOverrideSpec{LimitCPUToMemoryPercent: c.pct},
+				}),
+				cpuBaseScaleFactor: factor,
+			}
+			res := &corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(c.memory)},
+			}
+			m.OverrideCPULimit(res)
+			got := res.Limits[corev1.ResourceCPU]
+			assert.GreaterOrEqual(t, got.MilliValue(), int64(0), "must never be negative")
+			assert.Equal(t, c.want, got.MilliValue(), "exact saturated or floored value")
+		})
+	}
+}
+
+func TestSaturatingRoundedPercent(t *testing.T) {
+	// The helper recovers an integer percent from the float64 ratio for the legacy path and
+	// must never emit an arbitrary int64 for a non-finite input.
+	assert.Equal(t, int64(0), saturatingRoundedPercent(0))
+	assert.Equal(t, int64(29), saturatingRoundedPercent(0.29))
+	assert.Equal(t, int64(200), saturatingRoundedPercent(2.0))
+	assert.Equal(t, int64(math.MaxInt64), saturatingRoundedPercent(math.Inf(1)))
+	assert.Equal(t, int64(math.MinInt64), saturatingRoundedPercent(math.Inf(-1)))
+	assert.Equal(t, int64(0), saturatingRoundedPercent(math.NaN()), "NaN must not become an arbitrary int64")
+}
+
+func TestConvertExternalConfigPercentRoundTrip(t *testing.T) {
+	// Every supported request percentage (0..100) must survive int64 -> float64/100 ->
+	// Round(*100) exactly, so the CPU request paths are not off by 1m.
+	for p := int64(0); p <= 100; p++ {
+		c := ConvertExternalConfig(&ClusterResourceOverride{
+			Spec: ClusterResourceOverrideSpec{
+				CPURequestToLimitPercent:   p,
+				CPURequestToRequestPercent: p,
+			},
+		})
+		assert.Equal(t, p, saturatingRoundedPercent(c.CpuRequestToLimitRatio), "cpuRequestToLimit percent %d", p)
+		assert.Equal(t, p, saturatingRoundedPercent(c.CpuRequestToRequestRatio), "cpuRequestToRequest percent %d", p)
+	}
+}
+
+func TestMutator_OverrideCPULimitHonorsScaleFactor(t *testing.T) {
+	// cpuBaseScaleFactor is an exported NewMutator parameter; a non-default factor must be
+	// honored, not silently ignored. Doubling the default scale doubles the result.
+	build := func(f float64) *podMutator {
+		m, err := NewMutator(
+			&Config{LimitCPUToMemoryRatio: 1.0},
+			&CPUMemory{}, &CPUMemory{}, f,
+		)
+		require.NoError(t, err)
+		return m
+	}
+	res := func() *corev1.ResourceRequirements {
+		return &corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+		}
+	}
+
+	def := res()
+	build(factor).OverrideCPULimit(def)
+	validate(t, def.Limits, corev1.ResourceCPU, resource.MustParse("1000m"))
+
+	doubled := res()
+	build(2 * factor).OverrideCPULimit(doubled)
+	validate(t, doubled.Limits, corev1.ResourceCPU, resource.MustParse("2000m"))
+}
+
+func TestNewMutator_RejectsInvalidScaleFactor(t *testing.T) {
+	for _, f := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), -1} {
+		_, err := NewMutator(&Config{}, &CPUMemory{}, &CPUMemory{}, f)
+		assert.Error(t, err, "factor %v should be rejected", f)
+	}
+	_, err := NewMutator(&Config{}, &CPUMemory{}, &CPUMemory{}, factor)
+	assert.NoError(t, err)
+}
+
+func TestNewMutator_RejectsNonFiniteRatio(t *testing.T) {
+	// A NaN or infinite ratio (only reachable from a directly built Config) must fail
+	// construction rather than be silently treated as 0% at admission time.
+	for _, c := range []*Config{
+		{LimitCPUToMemoryRatio: math.NaN()},
+		{CpuRequestToLimitRatio: math.Inf(1)},
+		{MemoryRequestToLimitRatio: math.Inf(-1)},
+		{CpuRequestToRequestRatio: math.NaN()},
+	} {
+		_, err := NewMutator(c, &CPUMemory{}, &CPUMemory{}, factor)
+		assert.Error(t, err, "non-finite ratio should be rejected")
+	}
+	_, err := NewMutator(&Config{LimitCPUToMemoryRatio: 2.0}, &CPUMemory{}, &CPUMemory{}, factor)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
#### What this PR does / why we need it

The three CPU override paths computed `int64(float64(x) * ratio)`, which truncates toward zero. For an integer percentage the float product lands just below the exact integer (`float64(100)*0.29` is `28.999999999999996`), so the CPU request or limit was undercounted by 1m: 100m at 29% became 28m, and a 1536Mi memory limit at 29% produced a 434m CPU limit instead of 435m. The default CPU floor is 1m, so these were not masked by the floor.

`OverrideCPUWithLimit` and `OverrideCPUWithRequest` are `milliValue * pct / 100`, so this recovers the integer percent with `math.Round` and does the multiply in `math/big.Int`, the same fix applied to the memory request in #109. `OverrideCPULimit` scales memory bytes to millicores by the `cpuBaseScaleFactor` (default 1000 millicores per 1GiB); it applies that factor as an exact rational and floors the big.Int result, keeping the historical floor semantics while no longer losing an exactly-integer result to float64 error.

All three paths handle a whole-number percent the same way: recover it and do the arithmetic in `big.Int` (with `cpuBaseScaleFactor`'s exact rational form in `OverrideCPULimit`, whose default `1000/2^30` is exactly representable) so the floored result is exact rather than lost to float64 error, and saturate at the int64 bounds (`saturatingRoundedPercent`, `saturatingInt64`) so a percentage large enough to lose a unit in the round-trip cannot wrap to a negative CPU quantity. Exact preservation of the full unbounded int64 percentage is tracked in #115. Every value `ConvertExternalConfig` produces is a whole percent, so this is the path the operator and file configurations take. A ratio that is not a whole percent is only reachable from a directly built `Config`, which #118's `Config.Validate` accepts across `[0,1]`; it is scaled linearly instead of being rounded to a percent, so 0.5% of 1000m is 5m rather than 10m, and the two PRs agree on what a ratio in that range means. `NewMutator` rejects a NaN, infinite, or negative scale factor. New tests exercise both the whole-percent and fractional paths across all three overrides, the CPU-limit floor boundaries (768Mi at 29% is exactly 217.5m and floors to 217m), the exact saturation values at the int64 ceiling, the percent helper's boundaries including NaN, and the 0..100 request-percent round-trip.

Fixes #112
Refs #115

One pre-existing edge is out of scope here: an astronomically large *Pod* quantity can overflow int64 before the arithmetic runs, independent of the configured percentage. On the two request paths this is `limit.MilliValue()` / `request.MilliValue()`; in `OverrideCPULimit` it is `limit.Value()` on the memory limit (a DecimalSI quantity above `MaxInt64` bytes). That, and startup validation of the configured percentages, is tracked in #115 and the config-validation work in #118.

#### Does this PR introduce a user-facing change?

```release-note
Fixed CPU request and limit override calculations that could understate the result by 1m due to floating-point truncation (for example a 29% ratio).
```




