### PR TITLE
Hash long container names in the original CPU request annotation key

### DIFF
--- a/pkg/clusterresourceoverride/mutator.go
+++ b/pkg/clusterresourceoverride/mutator.go
@@ -1,6 +1,8 @@
 package clusterresourceoverride
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -56,10 +58,18 @@ func (m *podMutator) Mutate(in *corev1.Pod) (out *corev1.Pod, err error) {
 }
 
 const (
-	SpcType                      = "spc_t"
-	SelinuxRelabelResource       = "forceselinuxrelabel"
-	SelinuxRelabelGroup          = "admission.node.openshift.io"
-	OriginalCPURequestAnnotation = "clusterresourceoverrides.admission.autoscaling.openshift.io/original-cpu-request"
+	SpcType                = "spc_t"
+	SelinuxRelabelResource = "forceselinuxrelabel"
+	SelinuxRelabelGroup    = "admission.node.openshift.io"
+
+	// originalCPURequestName is the name segment of OriginalCPURequestAnnotation; the
+	// per-container key appends "-<container>" (or "-hash.<digest>") to it.
+	originalCPURequestName       = "original-cpu-request"
+	OriginalCPURequestAnnotation = "clusterresourceoverrides.admission.autoscaling.openshift.io/" + originalCPURequestName
+
+	// annotationNameSegmentMaxLength is the Kubernetes limit on an annotation key's
+	// name segment (the part after the "/").
+	annotationNameSegmentMaxLength = 63
 )
 
 var (
@@ -106,6 +116,24 @@ func (m *podMutator) Override(container *corev1.Container, current *corev1.Pod) 
 	m.OverrideCPUWithRequest(&container.Resources, container.Name, current)
 }
 
+// originalCPURequestKey returns the annotation key that stores a container's
+// original CPU request. The name segment of an annotation key (the part after the
+// "/") is limited to 63 characters, and a container name can be that long on its
+// own, so a name that would overflow the limit is replaced with a fixed-length hash
+// of the name. Shorter names keep the readable form. Both the writer and the reader
+// derive the key with this helper, so they always agree.
+func originalCPURequestKey(name string) string {
+	suffix := name
+	// The name segment is originalCPURequestName + "-" + suffix; keep it within the limit.
+	if len(originalCPURequestName)+1+len(name) > annotationNameSegmentMaxLength {
+		sum := sha256.Sum256([]byte(name))
+		// A container name is a DNS label and cannot contain a dot, so the "hash."
+		// marker keeps hashed suffixes in a namespace a readable name can never occupy.
+		suffix = "hash." + hex.EncodeToString(sum[:16])
+	}
+	return OriginalCPURequestAnnotation + "-" + suffix
+}
+
 // Annotates pod with original CPU request value. Annotation provides idempotency for
 // OverrideCPUWithRequest in case of reinvocation. Also preserves original value in case
 // of OverrideCPUWithLimit modifying the request prior to OverrideCPUWithRequest.
@@ -118,7 +146,7 @@ func (m *podMutator) AnnotateOriginalRequest(resources *corev1.ResourceRequireme
 		pod.Annotations = map[string]string{}
 	}
 
-	key := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, name)
+	key := originalCPURequestKey(name)
 	_, found := pod.Annotations[key]
 	if !found {
 		request := resources.Requests[corev1.ResourceCPU]
@@ -248,7 +276,7 @@ func (m *podMutator) OverrideCPUWithRequest(resources *corev1.ResourceRequiremen
 		return
 	}
 
-	key := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, name)
+	key := originalCPURequestKey(name)
 	strValue, found := pod.Annotations[key]
 	if !found {
 		klog.Warningf("failed to find %q annotation for pod %s/%s; skipping CPU request override", key, pod.Namespace, pod.Name)

--- a/pkg/clusterresourceoverride/mutator_test.go
+++ b/pkg/clusterresourceoverride/mutator_test.go
@@ -2,13 +2,16 @@ package clusterresourceoverride
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -16,10 +19,10 @@ const (
 )
 
 func TestMutator_Mutate(t *testing.T) {
-	
+
 	cpu := resource.MustParse("1m")
 	memory := resource.MustParse("1Mi")
-	
+
 	// Tests the mutator using CPURequestToLimitRatio as the CPU request override
 	t.Run("WithCpuRequestToLimitRatio", func(t *testing.T) {
 		floor := &CPUMemory{
@@ -92,11 +95,11 @@ func TestMutator_Mutate(t *testing.T) {
 		validate(t, podGot.Spec.Containers[1].Resources.Limits, corev1.ResourceCPU, resource.MustParse("4000m"))
 		validate(t, podGot.Spec.Containers[1].Resources.Requests, corev1.ResourceCPU, resource.MustParse("1000m"))
 	})
-	
+
 	// Tests mutator using CPURequestToRequestRatio as the CPU resource override
 	// Ensures CPURequestToRequestRatio overwrites CPURequestToLimitRatio
 	// Ensures CPURequestToRequestRatio doesn't compute with request from CPURequestToLimitRatio
-	// Tests the per container annotations to ensure the mutator applies the override 
+	// Tests the per container annotations to ensure the mutator applies the override
 	//   according to each container's original request
 	t.Run("WithCpuRequestToRequestRatio", func(t *testing.T) {
 		floor := &CPUMemory{
@@ -319,7 +322,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 	testAnnotation := fmt.Sprintf("%s-%s", OriginalCPURequestAnnotation, testContainerName)
 	tests := []struct {
 		name    string
-		pod *corev1.Pod
+		pod     *corev1.Pod
 		mutator func() *podMutator
 		input   *corev1.ResourceRequirements
 		assert  func(t *testing.T, resources *corev1.ResourceRequirements)
@@ -330,7 +333,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -354,7 +357,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 				},
 			},
 			mutator: func() *podMutator {
@@ -376,7 +379,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -402,7 +405,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -430,7 +433,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "1000m",
 					},
@@ -460,7 +463,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "2000m",
 					},
@@ -490,7 +493,7 @@ func TestMutator_OverrideCPUWithRequest(t *testing.T) {
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-ns",
-					Name: "test",
+					Name:      "test",
 					Annotations: map[string]string{
 						testAnnotation: "1000m",
 					},
@@ -1084,4 +1087,56 @@ func validate(t *testing.T, list corev1.ResourceList, name corev1.ResourceName, 
 
 	result := got.Equal(want)
 	require.True(t, result, "mutated, expected: %v, got %v", want, got)
+}
+
+func TestMutator_OriginalCPURequestKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		container  string
+		wantHashed bool
+	}{
+		{"short readable name", "app", false},
+		{"largest readable name", strings.Repeat("a", 42), false},
+		{"first hashed name", strings.Repeat("a", 43), true},
+		{"maximum container name", strings.Repeat("a", 63), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := originalCPURequestKey(tt.container)
+			// The key must be a valid annotation key, not merely within the length limit.
+			errs := apivalidation.ValidateAnnotations(map[string]string{key: "100m"}, field.NewPath("metadata", "annotations"))
+			require.Emptyf(t, errs, "invalid annotation key %q: %v", key, errs)
+			if tt.wantHashed {
+				// Hashed suffixes live in a reserved "hash." namespace a readable
+				// container name (a DNS label, which cannot contain a dot) can never occupy.
+				assert.Contains(t, key, "-hash.")
+			} else {
+				assert.Equal(t, OriginalCPURequestAnnotation+"-"+tt.container, key)
+			}
+		})
+	}
+
+	// Distinct long names map to distinct keys.
+	assert.NotEqual(t,
+		originalCPURequestKey(strings.Repeat("a", 63)),
+		originalCPURequestKey(strings.Repeat("b", 63)))
+}
+
+func TestMutator_OverrideCPUWithRequestHandlesLongContainerName(t *testing.T) {
+	m := &podMutator{config: ConvertExternalConfig(&ClusterResourceOverride{
+		Spec: ClusterResourceOverrideSpec{CPURequestToRequestPercent: 50},
+	})}
+	name := strings.Repeat("a", 63) // a valid, maximum-length container name
+	pod := &corev1.Pod{}
+	res := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+	}
+	// The webhook records the original request; the key it writes must be a valid
+	// annotation key.
+	m.AnnotateOriginalRequest(res, name, pod)
+	errs := apivalidation.ValidateAnnotations(pod.Annotations, field.NewPath("metadata", "annotations"))
+	require.Emptyf(t, errs, "webhook wrote invalid annotations: %v", errs)
+	// It must then read that same annotation back and compute the request from it.
+	m.OverrideCPUWithRequest(res, name, pod)
+	validate(t, res.Requests, corev1.ResourceCPU, resource.MustParse("50m"))
 }


### PR DESCRIPTION
#### What this PR does / why we need it

`AnnotateOriginalRequest` stores a container's original CPU request in a per-container annotation keyed as `.../original-cpu-request-<containerName>`. A Kubernetes annotation key's name segment (the part after the `/`) is limited to 63 characters, and `original-cpu-request-` already uses 21 of them, so a container name of 43 characters or more, which is still a valid DNS label, produces an over-length, invalid key. The webhook writes that annotation when `cpuRequestToRequestPercent` is configured and the container has a non-zero CPU request, so such a Pod is then rejected during admission even though the container name is valid.

The key is now derived through a shared helper used by both the writer (`AnnotateOriginalRequest`) and the reader (`OverrideCPUWithRequest`): names that fit keep the readable `-<name>` form, so existing Pods and short names are unchanged, and longer names fall back to a truncated SHA-256 of the name under a reserved `hash.` namespace. A container name is a DNS label and cannot contain a dot, so a hashed key can never coincide with a readable one. Because both sites use the same helper, the key still round-trips.

Fixes #114

#### Does this PR introduce a user-facing change?

```release-note
Fixed Pod admission failing for containers whose names are 43 characters or longer when cpuRequestToRequestPercent is configured and the container has a non-zero CPU request, which was caused by an over-length generated annotation key.
```
