### PR TITLE
Validate override percentages when loading configuration

### DIFF
--- a/pkg/clusterresourceoverride/admission.go
+++ b/pkg/clusterresourceoverride/admission.go
@@ -82,7 +82,7 @@ func NewInClusterAdmission(kubeClientConfig *restclient.Config, stopCh <-chan st
 
 		externalConfig, decodeErr := DecodeWithFile(configPath)
 		if decodeErr != nil {
-			err = fmt.Errorf("name=%s file=%s failed to decode configuration - %s", Name, configPath, decodeErr.Error())
+			err = fmt.Errorf("name=%s file=%s failed to decode configuration: %w", Name, configPath, decodeErr)
 			return
 		}
 
@@ -119,9 +119,17 @@ func NewAdmission(kubeClientConfig *restclient.Config, stopCh <-chan struct{}, c
 		return
 	}
 
+	// Guard the nil case before client-go dereferences it: NewForConfig copies *kubeClientConfig
+	// immediately, so a nil argument would panic instead of returning an error. This runs after
+	// Validate so an invalid configuration is still reported before the client is considered.
+	if kubeClientConfig == nil {
+		err = fmt.Errorf("name=%s failed to create Kubernetes client: kube client config is nil", Name)
+		return
+	}
+
 	client, clientErr := kubernetes.NewForConfig(kubeClientConfig)
 	if clientErr != nil {
-		err = fmt.Errorf("name=%s failed to load configuration - %s", Name, clientErr.Error())
+		err = fmt.Errorf("name=%s failed to create Kubernetes client: %w", Name, clientErr)
 		return
 	}
 

--- a/pkg/clusterresourceoverride/admission.go
+++ b/pkg/clusterresourceoverride/admission.go
@@ -118,6 +118,11 @@ func NewAdmission(kubeClientConfig *restclient.Config, stopCh <-chan struct{}, c
 		err = fmt.Errorf("name=%s invalid configuration: %w", Name, validateErr)
 		return
 	}
+	// Store a copy so a caller that retains and later mutates the config it passed cannot change
+	// the validated configuration the admission runs with. Config holds only scalar fields, so a
+	// shallow copy is a full copy.
+	validatedConfig := *config
+	config = &validatedConfig
 
 	// Guard the nil case before client-go dereferences it: NewForConfig copies *kubeClientConfig
 	// immediately, so a nil argument would panic instead of returning an error. This runs after
@@ -195,7 +200,13 @@ type clusterResourceOverrideAdmission struct {
 }
 
 func (p *clusterResourceOverrideAdmission) GetConfiguration() *Config {
-	return p.config
+	if p == nil || p.config == nil {
+		return nil
+	}
+	// Return a copy so a caller cannot mutate the admission's validated configuration through
+	// the returned pointer.
+	configCopy := *p.config
+	return &configCopy
 }
 
 func (p *clusterResourceOverrideAdmission) IsApplicable(request *admissionv1.AdmissionRequest) bool {

--- a/pkg/clusterresourceoverride/admission.go
+++ b/pkg/clusterresourceoverride/admission.go
@@ -101,6 +101,19 @@ func NewAdmission(kubeClientConfig *restclient.Config, stopCh <-chan struct{}, c
 		err = fmt.Errorf("name=%s failed to load configuration - %s", Name, configLoadErr.Error())
 		return
 	}
+	// Validate here rather than in a particular loader: NewAdmission is the single
+	// boundary every ConfigLoaderFunc passes through, so a programmatic loader (the only
+	// source that can produce a non-finite or out-of-range ratio, since the configuration
+	// file's percentages are int64) cannot bypass it. This runs before the client is
+	// built, so an invalid configuration fails fast without contacting the API server.
+	if config == nil {
+		err = fmt.Errorf("name=%s failed to load configuration - loader returned nil config", Name)
+		return
+	}
+	if validateErr := config.Validate(); validateErr != nil {
+		err = fmt.Errorf("name=%s invalid configuration - %s", Name, validateErr.Error())
+		return
+	}
 
 	client, clientErr := kubernetes.NewForConfig(kubeClientConfig)
 	if clientErr != nil {

--- a/pkg/clusterresourceoverride/admission.go
+++ b/pkg/clusterresourceoverride/admission.go
@@ -95,6 +95,10 @@ func NewInClusterAdmission(kubeClientConfig *restclient.Config, stopCh <-chan st
 
 // NewAdmission constructs an Admission using the supplied configuration loader.
 func NewAdmission(kubeClientConfig *restclient.Config, stopCh <-chan struct{}, configLoaderFunc ConfigLoaderFunc) (admission Admission, err error) {
+	if configLoaderFunc == nil {
+		err = fmt.Errorf("name=%s failed to load configuration - loader is nil", Name)
+		return
+	}
 	config, configLoadErr := configLoaderFunc()
 	if configLoadErr != nil {
 		err = fmt.Errorf("name=%s failed to load configuration: %w", Name, configLoadErr)

--- a/pkg/clusterresourceoverride/admission.go
+++ b/pkg/clusterresourceoverride/admission.go
@@ -93,25 +93,25 @@ func NewInClusterAdmission(kubeClientConfig *restclient.Config, stopCh <-chan st
 	return NewAdmission(kubeClientConfig, stopCh, configLoader)
 }
 
-// NewInClusterAdmission returns a new instance of Admission that is appropriate
-// to be consumed in cluster.
+// NewAdmission constructs an Admission using the supplied configuration loader.
 func NewAdmission(kubeClientConfig *restclient.Config, stopCh <-chan struct{}, configLoaderFunc ConfigLoaderFunc) (admission Admission, err error) {
 	config, configLoadErr := configLoaderFunc()
 	if configLoadErr != nil {
-		err = fmt.Errorf("name=%s failed to load configuration - %s", Name, configLoadErr.Error())
+		err = fmt.Errorf("name=%s failed to load configuration: %w", Name, configLoadErr)
 		return
 	}
-	// Validate here rather than in a particular loader: NewAdmission is the single
-	// boundary every ConfigLoaderFunc passes through, so a programmatic loader (the only
-	// source that can produce a non-finite or out-of-range ratio, since the configuration
-	// file's percentages are int64) cannot bypass it. This runs before the client is
-	// built, so an invalid configuration fails fast without contacting the API server.
+	// Validate here rather than in a particular loader: NewAdmission is the common boundary
+	// every ConfigLoaderFunc passes through. A file-backed loader can produce an out-of-range
+	// ratio (for example a 101% percentage), and a programmatic loader can additionally
+	// produce a non-finite one; validating here means neither can bypass the check. This runs
+	// before the client is built, so an invalid configuration fails fast without contacting
+	// the API server.
 	if config == nil {
 		err = fmt.Errorf("name=%s failed to load configuration - loader returned nil config", Name)
 		return
 	}
 	if validateErr := config.Validate(); validateErr != nil {
-		err = fmt.Errorf("name=%s invalid configuration - %s", Name, validateErr.Error())
+		err = fmt.Errorf("name=%s invalid configuration: %w", Name, validateErr)
 		return
 	}
 

--- a/pkg/clusterresourceoverride/admission_test.go
+++ b/pkg/clusterresourceoverride/admission_test.go
@@ -1,6 +1,7 @@
 package clusterresourceoverride
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,6 +44,27 @@ func TestNewAdmissionValidatesConfiguration(t *testing.T) {
 		require.Nil(t, admission)
 		assert.Contains(t, err.Error(), "nil config")
 	})
+}
+
+func TestNewAdmissionRejectsNilKubeClientConfig(t *testing.T) {
+	// A valid config must fail cleanly, not panic, when the kube client config is nil:
+	// client-go's NewForConfig dereferences it immediately. The guard runs after config
+	// validation, so an invalid config is still reported before this one.
+	loader := func() (*Config, error) { return &Config{}, nil }
+	admission, err := NewAdmission(nil, nil, loader)
+	require.Error(t, err)
+	require.Nil(t, admission)
+	assert.Contains(t, err.Error(), "kube client config is nil")
+}
+
+func TestNewAdmissionWrapsLoaderError(t *testing.T) {
+	// The loader's error is wrapped with %w, so a caller can match the underlying cause.
+	loadErr := errors.New("load failed")
+	loader := func() (*Config, error) { return nil, loadErr }
+	admission, err := NewAdmission(nil, nil, loader)
+	require.Error(t, err)
+	require.Nil(t, admission)
+	require.ErrorIs(t, err, loadErr)
 }
 
 func TestNewInClusterAdmissionRejectsInvalidConfigFile(t *testing.T) {

--- a/pkg/clusterresourceoverride/admission_test.go
+++ b/pkg/clusterresourceoverride/admission_test.go
@@ -1,6 +1,8 @@
 package clusterresourceoverride
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +13,45 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 )
+
+func TestNewAdmissionValidatesConfiguration(t *testing.T) {
+	// NewAdmission is the single boundary every ConfigLoaderFunc passes through, so an
+	// invalid config must be rejected there, before any API client is built, regardless of
+	// which loader produced it.
+	t.Run("rejects an out-of-range ratio", func(t *testing.T) {
+		loader := func() (*Config, error) {
+			return &Config{CpuRequestToLimitRatio: 1.5}, nil
+		}
+		admission, err := NewAdmission(nil, nil, loader)
+		require.Error(t, err)
+		require.Nil(t, admission)
+		assert.Contains(t, err.Error(), "invalid configuration")
+		assert.Contains(t, err.Error(), "cpuRequestToLimitRatio")
+	})
+
+	t.Run("rejects a nil config from the loader", func(t *testing.T) {
+		loader := func() (*Config, error) { return nil, nil }
+		admission, err := NewAdmission(nil, nil, loader)
+		require.Error(t, err)
+		require.Nil(t, admission)
+		assert.Contains(t, err.Error(), "nil config")
+	})
+}
+
+func TestNewInClusterAdmissionRejectsInvalidConfigFile(t *testing.T) {
+	// A hand-edited configuration file with an out-of-range percentage must fail startup
+	// before the API client is created, so no cluster is needed here.
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := "apiVersion: v1\nkind: ClusterResourceOverrideConfig\nspec:\n  cpuRequestToLimitPercent: 101\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	t.Setenv(configurationEnvName, path)
+
+	admission, err := NewInClusterAdmission(nil, nil)
+	require.Error(t, err)
+	require.Nil(t, admission)
+	assert.Contains(t, err.Error(), "invalid configuration")
+	assert.Contains(t, err.Error(), "cpuRequestToLimitRatio")
+}
 
 func TestSetNamespaceFloor(t *testing.T) {
 	cpu := resource.MustParse("1000m")

--- a/pkg/clusterresourceoverride/admission_test.go
+++ b/pkg/clusterresourceoverride/admission_test.go
@@ -67,6 +67,16 @@ func TestNewAdmissionWrapsLoaderError(t *testing.T) {
 	require.ErrorIs(t, err, loadErr)
 }
 
+func TestGetConfigurationReturnsCopy(t *testing.T) {
+	// GetConfiguration must not expose the admission's validated config for mutation: a caller
+	// changing the returned value must not change the configuration admission runs with.
+	admission := &clusterResourceOverrideAdmission{config: &Config{CpuRequestToLimitRatio: 0.5}}
+	got := admission.GetConfiguration()
+	require.NotNil(t, got)
+	got.CpuRequestToLimitRatio = 1.5
+	assert.Equal(t, 0.5, admission.GetConfiguration().CpuRequestToLimitRatio, "internal config must be unchanged")
+}
+
 func TestNewInClusterAdmissionRejectsInvalidConfigFile(t *testing.T) {
 	// A hand-edited configuration file with an out-of-range percentage must fail startup
 	// before the API client is created, so no cluster is needed here.

--- a/pkg/clusterresourceoverride/admission_test.go
+++ b/pkg/clusterresourceoverride/admission_test.go
@@ -29,6 +29,13 @@ func TestNewAdmissionValidatesConfiguration(t *testing.T) {
 		assert.Contains(t, err.Error(), "cpuRequestToLimitRatio")
 	})
 
+	t.Run("rejects a nil loader", func(t *testing.T) {
+		admission, err := NewAdmission(nil, nil, nil)
+		require.Error(t, err)
+		require.Nil(t, admission)
+		assert.Contains(t, err.Error(), "loader is nil")
+	})
+
 	t.Run("rejects a nil config from the loader", func(t *testing.T) {
 		loader := func() (*Config, error) { return nil, nil }
 		admission, err := NewAdmission(nil, nil, loader)

--- a/pkg/clusterresourceoverride/config.go
+++ b/pkg/clusterresourceoverride/config.go
@@ -106,7 +106,7 @@ func Decode(reader io.Reader) (object *ClusterResourceOverride, err error) {
 func DecodeWithFile(path string) (object *ClusterResourceOverride, err error) {
 	reader, openErr := os.Open(path)
 	if openErr != nil {
-		err = fmt.Errorf("unable to load file %s: %s", path, openErr)
+		err = fmt.Errorf("unable to load file %s: %w", path, openErr)
 		return
 	}
 	defer func() {

--- a/pkg/clusterresourceoverride/config.go
+++ b/pkg/clusterresourceoverride/config.go
@@ -3,6 +3,7 @@ package clusterresourceoverride
 import (
 	"fmt"
 	"io"
+	"math"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +52,31 @@ type Config struct {
 func (c *Config) String() string {
 	return fmt.Sprintf("LimitCPUToMemoryRatio=%f CpuRequestToLimitRatio=%f MemoryRequestToLimitRatio=%f CpuRequestToRequestRatio=%f ForceSelinuxRelabel=%v",
 		c.LimitCPUToMemoryRatio, c.CpuRequestToLimitRatio, c.MemoryRequestToLimitRatio, c.CpuRequestToRequestRatio, c.ForceSelinuxRelabel)
+}
+
+// Validate rejects a Config whose ratios are not finite and in range so an
+// invalid configuration (for example a hand-edited configuration file the
+// operator did not produce) fails fast at load time instead of silently
+// producing wrong requests at admission. The three request ratios are fractions
+// of another value and must be in [0,1]; LimitCPUToMemoryRatio scales memory to
+// CPU (100% is 1 core per GiB) and only has to be finite and non-negative.
+func (c *Config) Validate() error {
+	for _, r := range []struct {
+		name  string
+		ratio float64
+	}{
+		{"cpuRequestToLimitRatio", c.CpuRequestToLimitRatio},
+		{"cpuRequestToRequestRatio", c.CpuRequestToRequestRatio},
+		{"memoryRequestToLimitRatio", c.MemoryRequestToLimitRatio},
+	} {
+		if math.IsNaN(r.ratio) || math.IsInf(r.ratio, 0) || r.ratio < 0 || r.ratio > 1 {
+			return fmt.Errorf("%s must be a finite value in [0,1], got %v", r.name, r.ratio)
+		}
+	}
+	if r := c.LimitCPUToMemoryRatio; math.IsNaN(r) || math.IsInf(r, 0) || r < 0 {
+		return fmt.Errorf("limitCPUToMemoryRatio must be a finite non-negative value, got %v", r)
+	}
+	return nil
 }
 
 func ConvertExternalConfig(object *ClusterResourceOverride) *Config {

--- a/pkg/clusterresourceoverride/config_test.go
+++ b/pkg/clusterresourceoverride/config_test.go
@@ -67,9 +67,10 @@ func TestConfigValidate(t *testing.T) {
 
 	// Accepted. The three request ratios are valid across the whole [0,1] range.
 	// LimitCPUToMemoryRatio has no upper bound: it mirrors the operator CRD, which only
-	// requires >= 0, so an arbitrarily large finite value is accepted here (and saturated
-	// by the CPU arithmetic downstream) rather than rejected at a bound the operator would
-	// not enforce.
+	// requires >= 0, so a large value (up to what the int64 external percentage can express)
+	// is accepted here rather than rejected at a bound the operator would not enforce. This
+	// PR validates the configured ranges only; overflow-safe arithmetic for a large
+	// CPU-to-memory percentage is handled in #113.
 	accepted := []struct {
 		name   string
 		mutate func(*Config)
@@ -82,7 +83,7 @@ func TestConfigValidate(t *testing.T) {
 			c.CpuRequestToLimitRatio, c.CpuRequestToRequestRatio, c.MemoryRequestToLimitRatio = 1, 1, 1
 		}},
 		{"limit-to-memory ratio zero", func(c *Config) { c.LimitCPUToMemoryRatio = 0 }},
-		{"limit-to-memory ratio very large finite", func(c *Config) { c.LimitCPUToMemoryRatio = math.MaxFloat64 }},
+		{"limit-to-memory ratio at the external maximum", func(c *Config) { c.LimitCPUToMemoryRatio = float64(math.MaxInt64) / 100 }},
 	}
 	for _, tc := range accepted {
 		t.Run("accepted/"+tc.name, func(t *testing.T) {
@@ -92,8 +93,8 @@ func TestConfigValidate(t *testing.T) {
 		})
 	}
 
-	// Rejected. Each error names the offending field so an operator can locate it in the
-	// configuration file.
+	// Rejected. Each error names the offending internal ratio field (not the YAML percentage
+	// key it was derived from).
 	rejected := []struct {
 		name   string
 		field  string

--- a/pkg/clusterresourceoverride/config_test.go
+++ b/pkg/clusterresourceoverride/config_test.go
@@ -1,11 +1,22 @@
 package clusterresourceoverride
 
 import (
+	"io/fs"
 	"math"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDecodeWithFileWrapsOpenError(t *testing.T) {
+	// The open error must be wrapped with %w so a caller can match it, for example to tell a
+	// missing file apart from a malformed one.
+	_, err := DecodeWithFile(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	require.Error(t, err)
+	require.ErrorIs(t, err, fs.ErrNotExist)
+}
 
 func TestConvertExternalConfig(t *testing.T) {
 	external := &ClusterResourceOverride{

--- a/pkg/clusterresourceoverride/config_test.go
+++ b/pkg/clusterresourceoverride/config_test.go
@@ -1,6 +1,7 @@
 package clusterresourceoverride
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,6 +51,71 @@ func TestDecodeWithFile(t *testing.T) {
 			objGot, errGot := DecodeWithFile(tt.file)
 
 			tt.assert(t, objGot, errGot)
+		})
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	valid := func() *Config {
+		return &Config{
+			CpuRequestToLimitRatio:    0.5,
+			CpuRequestToRequestRatio:  0.5,
+			MemoryRequestToLimitRatio: 0.5,
+			LimitCPUToMemoryRatio:     2.0,
+		}
+	}
+
+	// Accepted. The three request ratios are valid across the whole [0,1] range.
+	// LimitCPUToMemoryRatio has no upper bound: it mirrors the operator CRD, which only
+	// requires >= 0, so an arbitrarily large finite value is accepted here (and saturated
+	// by the CPU arithmetic downstream) rather than rejected at a bound the operator would
+	// not enforce.
+	accepted := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"midrange", func(c *Config) {}},
+		{"request ratios at zero", func(c *Config) {
+			c.CpuRequestToLimitRatio, c.CpuRequestToRequestRatio, c.MemoryRequestToLimitRatio = 0, 0, 0
+		}},
+		{"request ratios at one", func(c *Config) {
+			c.CpuRequestToLimitRatio, c.CpuRequestToRequestRatio, c.MemoryRequestToLimitRatio = 1, 1, 1
+		}},
+		{"limit-to-memory ratio zero", func(c *Config) { c.LimitCPUToMemoryRatio = 0 }},
+		{"limit-to-memory ratio very large finite", func(c *Config) { c.LimitCPUToMemoryRatio = math.MaxFloat64 }},
+	}
+	for _, tc := range accepted {
+		t.Run("accepted/"+tc.name, func(t *testing.T) {
+			c := valid()
+			tc.mutate(c)
+			assert.NoError(t, c.Validate())
+		})
+	}
+
+	// Rejected. Each error names the offending field so an operator can locate it in the
+	// configuration file.
+	rejected := []struct {
+		name   string
+		field  string
+		mutate func(*Config)
+	}{
+		{"request ratio just above one", "cpuRequestToLimitRatio", func(c *Config) { c.CpuRequestToLimitRatio = math.Nextafter(1, 2) }},
+		{"request ratio just below zero", "cpuRequestToRequestRatio", func(c *Config) { c.CpuRequestToRequestRatio = -math.SmallestNonzeroFloat64 }},
+		{"request ratio NaN", "memoryRequestToLimitRatio", func(c *Config) { c.MemoryRequestToLimitRatio = math.NaN() }},
+		{"request ratio +Inf", "cpuRequestToLimitRatio", func(c *Config) { c.CpuRequestToLimitRatio = math.Inf(1) }},
+		{"request ratio -Inf", "cpuRequestToRequestRatio", func(c *Config) { c.CpuRequestToRequestRatio = math.Inf(-1) }},
+		{"limit-to-memory ratio negative", "limitCPUToMemoryRatio", func(c *Config) { c.LimitCPUToMemoryRatio = -math.SmallestNonzeroFloat64 }},
+		{"limit-to-memory ratio NaN", "limitCPUToMemoryRatio", func(c *Config) { c.LimitCPUToMemoryRatio = math.NaN() }},
+		{"limit-to-memory ratio +Inf", "limitCPUToMemoryRatio", func(c *Config) { c.LimitCPUToMemoryRatio = math.Inf(1) }},
+	}
+	for _, tc := range rejected {
+		t.Run("rejected/"+tc.name, func(t *testing.T) {
+			c := valid()
+			tc.mutate(c)
+			err := c.Validate()
+			if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), tc.field, "error should name the offending field")
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it

The admission server can be configured through the operator or, in cluster, from a configuration file named by the `CONFIGURATION_PATH` environment variable. The percentages in that file are not validated in this repository, so an out-of-range or otherwise unsupported ratio is carried into admission where the arithmetic can produce a wrong request.

`Config.Validate` enforces the supported ranges: the three request ratios (CPU-to-limit, CPU-to-request, memory-to-limit) must be finite and in `[0,1]`, and `LimitCPUToMemoryRatio` must be finite and non-negative. It has no upper bound, mirroring the operator CRD (which only requires `>= 0`), so a large finite value (up to what the int64 external percentage can express) is accepted here rather than rejected at a bound the operator would not enforce. This PR validates the configured ranges only; overflow-safe arithmetic for a large CPU-to-memory percentage is handled in #113. Validation runs in `NewAdmission`, the single boundary every `ConfigLoaderFunc` passes through, before the API client is built, so an unsupported configuration fails startup instead of admitting Pods with wrong requests. (A file-backed loader produces out-of-range ratios such as a 101% percentage; the finite checks additionally matter for a programmatically constructed `Config`.) `NewAdmission` also returns a clear error for a nil loader or a nil client config instead of panicking, and wraps its startup errors with `%w` so callers can match them with `errors.Is`/`errors.As`. After validation it stores a copy of the `Config` and `GetConfiguration` returns a copy, so a caller that retains the config it passed (or the one it got back) cannot mutate the validated configuration admission runs with, or race with a concurrent `Admit`.

Refs #115

This is the configuration-range portion of #115 and intentionally does not close it. The `MilliValue()` magnitude check on the CPU request paths (a Pod-quantity overflow, independent of the configured percentage) remains tracked in #115. For an unbounded `LimitCPUToMemoryPercent`, #113 saturates the resulting CPU quantity rather than wrapping; exact preservation of the full percentage remains tracked in #115. Strict decoding of the configuration file (rejecting unknown or duplicate keys) is a separate pre-existing gap and is not addressed here.

#### Does this PR introduce a user-facing change?

```release-note
The cluster-resource-override admission server now rejects a configuration whose request percentages are outside 0-100 or whose CPU-to-memory percentage is negative, failing startup instead of applying unsupported overrides.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added stricter config validation to prevent startup with invalid admission settings (out-of-range and non-finite ratio values).
  - Improved failure behavior with clearer, more actionable errors when required configuration or Kubernetes client settings are missing.
  - Hardened configuration retrieval to return a defensive copy, preventing accidental external mutation.
  - Preserved original error causes via error wrapping for easier troubleshooting.

- **Tests**
  - Expanded coverage for validation, error-wrapping behavior, invalid on-disk configuration, nil-handling, and defensive copy semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
